### PR TITLE
Standardize demo credentials to use consistent password

### DIFF
--- a/demo/rhales-roda-demo/README.md
+++ b/demo/rhales-roda-demo/README.md
@@ -52,7 +52,7 @@ Expected output:
 ```
 Seed data created successfully!
 Demo accounts:
-  - demo@example.com / password123
+  - demo@example.com / demo123
   - user@example.com / userpass
 ```
 
@@ -88,7 +88,7 @@ You should see the Rhales Demo homepage with feature cards.
 1. Click **"Login"** in the top navigation
 2. Enter credentials:
    - Email: `demo@example.com`
-   - Password: `password123`
+   - Password: `demo123`
 3. Click **"Login"** button
 4. You should see a dashboard with:
    - Welcome message with the user's name

--- a/demo/rhales-roda-demo/db/seed.rb
+++ b/demo/rhales-roda-demo/db/seed.rb
@@ -4,9 +4,9 @@ require 'bcrypt'
 # Create demo account
 Account.create(
   email: 'demo@example.com',
-  password_hash: BCrypt::Password.create('password123'),
+  password_hash: BCrypt::Password.create('demo123'),
   name: 'Demo User',
 )
 
 puts 'Seed data created successfully!'
-puts 'Demo account: demo@example.com / password123'
+puts 'Demo account: demo@example.com / demo123'

--- a/demo/rhales-roda-demo/templates/auth/login.rue
+++ b/demo/rhales-roda-demo/templates/auth/login.rue
@@ -2,7 +2,7 @@
 {
   "title": "Login",
   "demo_accounts": [
-    {"email": "demo@example.com", "password": "password123"},
+    {"email": "demo@example.com", "password": "demo123"},
     {"email": "user@example.com", "password": "userpass"}
   ]
 }


### PR DESCRIPTION
## Summary
- Fixed password mismatch issue where different files used different demo passwords
- Standardized all demo credentials to use 'demo123' consistently
- Ensures demo account can be logged into successfully

## Changes
- Updated `db/seed.rb` to use 'demo123' instead of 'password123'
- Fixed login template to display correct demo credentials
- Updated README.md instructions with correct password
- All demo references now consistently use `demo@example.com` / `demo123`

## Test plan
- [ ] Run `bundle exec ruby db/seed.rb` and verify output shows 'demo123'
- [ ] Login with demo@example.com / demo123 and confirm successful authentication
- [ ] Verify README instructions match actual credentials

🤖 Generated with [Claude Code](https://claude.ai/code)