### PR TITLE
Fix Rodauth template integration and form syntax error

### DIFF
--- a/demo/rhales-roda-demo/app.rb
+++ b/demo/rhales-roda-demo/app.rb
@@ -95,10 +95,10 @@ class RhalesDemo < Roda
 
     # Use our Rhales templates instead of ERB
     login_view do
-      scope.rhales_render('auth/login')
+      scope.instance_eval { rhales_render('auth/login') }
     end
     create_account_view do
-      scope.rhales_render('auth/register')
+      scope.instance_eval { rhales_render('auth/register') }
     end
   end
 

--- a/demo/rhales-roda-demo/templates/auth/login.rue
+++ b/demo/rhales-roda-demo/templates/auth/login.rue
@@ -12,7 +12,7 @@
 <div class="card" style="max-width: 400px; margin: 0 auto;">
   <h2>{{title}}</h2>
 
-  <form method="post" action="/login">2
+  <form method="post" action="/login">
     {{runtime.csrf_field}}
 
     <div class="form-group">


### PR DESCRIPTION
## Summary
- Fixed Rodauth view integration to properly render Rhales templates
- Removed stray character causing HTML parsing issues in login form
- Ensures authentication views display correctly

## Changes
- Fixed `scope.rhales_render()` calls to use proper context with `instance_eval`
- Removed errant '2' character from login form tag that was breaking HTML
- Rodauth views now properly integrate with Rhales template engine

## Test plan
- [ ] Navigate to /login and verify form displays correctly
- [ ] Inspect form HTML to ensure no syntax errors
- [ ] Test account creation view renders properly
- [ ] Confirm authentication flow works end-to-end

🤖 Generated with [Claude Code](https://claude.ai/code)