### PR TITLE
Fix nonce consistency in Tilt integration

### DIFF
--- a/demo/rhales-roda-demo/app.rb
+++ b/demo/rhales-roda-demo/app.rb
@@ -180,7 +180,20 @@ class RhalesDemo < Roda
     rodauth.logged_in?
   end
 
+  # Generate a single nonce per request and set CSP header
+  def csp_nonce
+    @csp_nonce ||= SecureRandom.hex(16)
+  end
+
+  # Set CSP header with nonce
+  def set_csp_header
+    response.headers['Content-Security-Policy'] = "default-src 'self'; script-src 'self' 'nonce-#{csp_nonce}'; style-src 'self' 'nonce-#{csp_nonce}'"
+  end
+
   route do |r|
+    # Set CSP header for all requests
+    set_csp_header
+    
     r.rodauth
 
     # Home route - shows different content based on auth state


### PR DESCRIPTION
## Summary
Fixes nonce consistency issues in Rhales Tilt integration where different nonces were generated for each template render, causing CSP violations.

## Changes
- **lib/rhales/tilt.rb**: Modified to use shared nonce from scope instead of generating new ones
- **demo/rhales-roda-demo/app.rb**: Added CSP nonce generation and header support

## Problem Fixed
Before: Different nonces like `nonce="4cb80c8bcda045559830332ecb62fc4e"` and `nonce="3578a05d333cf1894e56df5def8ce2b4"`
After: Consistent nonces throughout response with proper CSP header

## Test plan
- [x] Verify all nonces in response are identical
- [x] Confirm CSP header is set correctly
- [x] Test across multiple templates in same request

🤖 Generated with [Claude Code](https://claude.ai/code)