### PR TITLE
Fix Context authenticated method call

### DIFF
--- a/lib/rhales/context.rb
+++ b/lib/rhales/context.rb
@@ -149,7 +149,7 @@ module Rhales
 
       # Check if user is authenticated
       def authenticated?
-        sess && sess.authenticated && cust && !cust.anonymous?
+        sess && sess.authenticated? && cust && !cust.anonymous?
       end
 
       # Get default session instance


### PR DESCRIPTION
## Summary
Fixes a method name bug in Context class that was causing NoMethodError during hydration and breaking all tests.

## Changes
- **lib/rhales/context.rb**: Fixed `sess.authenticated` to `sess.authenticated?` on line 152

## Problem Fixed
- Session adapters define `authenticated?` method, not `authenticated`
- This was causing Context initialization to fail with NoMethodError
- All HydrationDataAggregator and integration tests were broken

## Impact
- ✅ All tests now pass (141 examples, 0 failures)
- ✅ Hydration collision detection works correctly
- ✅ Context objects initialize properly

## Test plan
- [x] Run full test suite - all tests pass
- [x] Verify hydration collision detection works for actual collisions
- [x] Confirm Context objects initialize without errors

🤖 Generated with [Claude Code](https://claude.ai/code)