### PR TITLE
Fix multibyte UTF-8 character handling in hydration injection

### DIFF
--- a/lib/rhales/hydration/earliest_injection_detector.rb
+++ b/lib/rhales/hydration/earliest_injection_detector.rb
@@ -26,6 +26,8 @@ module Rhales
     def detect(template_html)
       scanner = StringScanner.new(template_html)
       validator = SafeInjectionValidator.new(template_html)
+      # Build byte-to-char map once for the entire template
+      @byte_to_char_map = build_byte_to_char_map(template_html)
 
       # Try head section injection points first
       head_injection_point = detect_head_injection_point(scanner, validator, template_html)
@@ -68,9 +70,9 @@ module Rhales
 
       # Find opening <body> tag
       if scanner.scan_until(/<body\b[^>]*>/i)
-        # Convert byte position to character position
+        # Convert byte position to character position using pre-built map
         byte_body_start = scanner.pos - scanner.matched.length
-        body_start = template_html.byteslice(0, byte_body_start).length
+        body_start = @byte_to_char_map[byte_body_start]
         safe_position = find_safe_injection_position(validator, body_start)
         return safe_position if safe_position
       end
@@ -83,15 +85,15 @@ module Rhales
 
       # Find opening <head> tag
       return nil unless scanner.scan_until(/<head\b[^>]*>/i)
-      # Convert byte position to character position
+      # Convert byte position to character position using pre-built map
       byte_head_start = scanner.pos
-      head_start = template_html.byteslice(0, byte_head_start).length
+      head_start = @byte_to_char_map[byte_head_start]
 
       # Find closing </head> tag
       return nil unless scanner.scan_until(/<\/head>/i)
-      # Convert byte position to character position
+      # Convert byte position to character position using pre-built map
       byte_head_end = scanner.pos - scanner.matched.length
-      head_end = template_html.byteslice(0, byte_head_end).length
+      head_end = @byte_to_char_map[byte_head_end]
 
       [head_start, head_end]
     end
@@ -100,12 +102,13 @@ module Rhales
       head_content = template_html[head_start...head_end]
       scanner = StringScanner.new(head_content)
       last_link_end = nil
+      byte_to_char_map = build_byte_to_char_map(head_content)
 
       while scanner.scan_until(/<link\b[^>]*\/?>/i)
         # scanner.pos is byte position within head_content
         byte_pos = scanner.pos
-        # Convert to character position within head_content
-        last_link_end = head_content.byteslice(0, byte_pos).length
+        # Convert to character position using pre-built map
+        last_link_end = byte_to_char_map[byte_pos]
       end
 
       last_link_end ? head_start + last_link_end : nil
@@ -115,12 +118,13 @@ module Rhales
       head_content = template_html[head_start...head_end]
       scanner = StringScanner.new(head_content)
       last_meta_end = nil
+      byte_to_char_map = build_byte_to_char_map(head_content)
 
       while scanner.scan_until(/<meta\b[^>]*\/?>/i)
         # scanner.pos is byte position within head_content
         byte_pos = scanner.pos
-        # Convert to character position within head_content
-        last_meta_end = head_content.byteslice(0, byte_pos).length
+        # Convert to character position using pre-built map
+        last_meta_end = byte_to_char_map[byte_pos]
       end
 
       last_meta_end ? head_start + last_meta_end : nil
@@ -129,6 +133,7 @@ module Rhales
     def find_after_first_script(template_html, head_start, head_end)
       head_content = template_html[head_start...head_end]
       scanner = StringScanner.new(head_content)
+      byte_to_char_map = build_byte_to_char_map(head_content)
 
       # Find first script opening tag
       if scanner.scan_until(/<script\b[^>]*>/i)
@@ -138,8 +143,8 @@ module Rhales
         if scanner.scan_until(/<\/script>/i)
           # scanner.pos is byte position within head_content
           byte_script_end = scanner.pos
-          # Convert to character position within head_content
-          first_script_end = head_content.byteslice(0, byte_script_end).length
+          # Convert to character position using pre-built map
+          first_script_end = byte_to_char_map[byte_script_end]
           return head_start + first_script_end
         end
       end
@@ -163,6 +168,44 @@ module Rhales
 
       # No safe position found
       nil
+    end
+
+    # Builds a mapping from byte positions to character positions for efficient
+    # conversion when processing UTF-8 strings with StringScanner.
+    #
+    # This method creates a hash where keys are byte positions and values are
+    # the corresponding character positions. For multibyte UTF-8 characters,
+    # only the starting byte position has an entry in the map.
+    #
+    # @param str [String] The UTF-8 encoded string to map
+    # @return [Hash<Integer, Integer>] A hash mapping byte positions to character positions
+    #
+    # @example ASCII string
+    #   build_byte_to_char_map("Hello")
+    #   # => {0=>0, 1=>1, 2=>2, 3=>3, 4=>4, 5=>5}
+    #
+    # @example UTF-8 with multibyte characters
+    #   build_byte_to_char_map("café")  # é is 2 bytes
+    #   # => {0=>0, 1=>1, 2=>2, 3=>3, 5=>4}  # Note: byte 4 is continuation byte
+    #
+    def build_byte_to_char_map(str)
+      map = {}
+      char_pos = 0
+      byte_pos = 0
+
+      # Iterate through each character (not byte) in the string
+      str.each_char do |char|
+        # Map the starting byte position of this character
+        map[byte_pos] = char_pos
+
+        # Advance byte position by the byte size of this character
+        byte_pos += char.bytesize
+        char_pos += 1
+      end
+
+      # Add final mapping for the end of the string
+      map[byte_pos] = char_pos
+      map
     end
   end
 end

--- a/lib/rhales/hydration/earliest_injection_detector.rb
+++ b/lib/rhales/hydration/earliest_injection_detector.rb
@@ -68,7 +68,9 @@ module Rhales
 
       # Find opening <body> tag
       if scanner.scan_until(/<body\b[^>]*>/i)
-        body_start = scanner.pos - scanner.matched.length
+        # Convert byte position to character position
+        byte_body_start = scanner.pos - scanner.matched.length
+        body_start = template_html.byteslice(0, byte_body_start).length
         safe_position = find_safe_injection_position(validator, body_start)
         return safe_position if safe_position
       end
@@ -81,11 +83,15 @@ module Rhales
 
       # Find opening <head> tag
       return nil unless scanner.scan_until(/<head\b[^>]*>/i)
-      head_start = scanner.pos
+      # Convert byte position to character position
+      byte_head_start = scanner.pos
+      head_start = template_html.byteslice(0, byte_head_start).length
 
       # Find closing </head> tag
       return nil unless scanner.scan_until(/<\/head>/i)
-      head_end = scanner.pos - scanner.matched.length
+      # Convert byte position to character position
+      byte_head_end = scanner.pos - scanner.matched.length
+      head_end = template_html.byteslice(0, byte_head_end).length
 
       [head_start, head_end]
     end
@@ -96,7 +102,10 @@ module Rhales
       last_link_end = nil
 
       while scanner.scan_until(/<link\b[^>]*\/?>/i)
-        last_link_end = scanner.pos
+        # scanner.pos is byte position within head_content
+        byte_pos = scanner.pos
+        # Convert to character position within head_content
+        last_link_end = head_content.byteslice(0, byte_pos).length
       end
 
       last_link_end ? head_start + last_link_end : nil
@@ -108,7 +117,10 @@ module Rhales
       last_meta_end = nil
 
       while scanner.scan_until(/<meta\b[^>]*\/?>/i)
-        last_meta_end = scanner.pos
+        # scanner.pos is byte position within head_content
+        byte_pos = scanner.pos
+        # Convert to character position within head_content
+        last_meta_end = head_content.byteslice(0, byte_pos).length
       end
 
       last_meta_end ? head_start + last_meta_end : nil
@@ -120,11 +132,14 @@ module Rhales
 
       # Find first script opening tag
       if scanner.scan_until(/<script\b[^>]*>/i)
-        script_start = scanner.pos - scanner.matched.length
+        # We don't need script_start for this method, so we can skip it
 
         # Find corresponding closing tag
         if scanner.scan_until(/<\/script>/i)
-          first_script_end = scanner.pos
+          # scanner.pos is byte position within head_content
+          byte_script_end = scanner.pos
+          # Convert to character position within head_content
+          first_script_end = head_content.byteslice(0, byte_script_end).length
           return head_start + first_script_end
         end
       end

--- a/lib/rhales/hydration/earliest_injection_detector.rb
+++ b/lib/rhales/hydration/earliest_injection_detector.rb
@@ -137,7 +137,7 @@ module Rhales
 
       # Find first script opening tag
       if scanner.scan_until(/<script\b[^>]*>/i)
-        # We don't need script_start for this method, so we can skip it
+        # Only the script end position is needed for this method, not the start position
 
         # Find corresponding closing tag
         if scanner.scan_until(/<\/script>/i)

--- a/lib/rhales/hydration/safe_injection_validator.rb
+++ b/lib/rhales/hydration/safe_injection_validator.rb
@@ -60,11 +60,15 @@ module Rhales
         scanner.pos = 0
 
         while scanner.scan_until(context[:start])
-          start_pos = scanner.pos - scanner.matched.length
+          # Convert byte position to character position
+          byte_start_pos = scanner.pos - scanner.matched.length
+          start_pos = @html.byteslice(0, byte_start_pos).length
 
           # Find the corresponding end tag
           if scanner.scan_until(context[:end])
-            end_pos = scanner.pos
+            # Convert byte position to character position
+            byte_end_pos = scanner.pos
+            end_pos = @html.byteslice(0, byte_end_pos).length
             ranges << (start_pos...end_pos)
           else
             # If no closing tag found, consider rest of document unsafe

--- a/lib/rhales/hydration/safe_injection_validator.rb
+++ b/lib/rhales/hydration/safe_injection_validator.rb
@@ -55,20 +55,21 @@ module Rhales
     def calculate_unsafe_ranges
       ranges = []
       scanner = StringScanner.new(@html)
+      byte_to_char_map = build_byte_to_char_map(@html)
 
       UNSAFE_CONTEXTS.each do |context|
         scanner.pos = 0
 
         while scanner.scan_until(context[:start])
-          # Convert byte position to character position
+          # Convert byte position to character position using pre-built map
           byte_start_pos = scanner.pos - scanner.matched.length
-          start_pos = @html.byteslice(0, byte_start_pos).length
+          start_pos = byte_to_char_map[byte_start_pos]
 
           # Find the corresponding end tag
           if scanner.scan_until(context[:end])
-            # Convert byte position to character position
+            # Convert byte position to character position using pre-built map
             byte_end_pos = scanner.pos
-            end_pos = @html.byteslice(0, byte_end_pos).length
+            end_pos = byte_to_char_map[byte_end_pos]
             ranges << (start_pos...end_pos)
           else
             # If no closing tag found, consider rest of document unsafe
@@ -102,6 +103,44 @@ module Rhales
       end
 
       pos < @html.length && @html[pos] == '<'
+    end
+
+    # Builds a mapping from byte positions to character positions for efficient
+    # conversion when processing UTF-8 strings with StringScanner.
+    #
+    # This method creates a hash where keys are byte positions and values are
+    # the corresponding character positions. For multibyte UTF-8 characters,
+    # only the starting byte position has an entry in the map.
+    #
+    # @param str [String] The UTF-8 encoded string to map
+    # @return [Hash<Integer, Integer>] A hash mapping byte positions to character positions
+    #
+    # @example ASCII string
+    #   build_byte_to_char_map("Hello")
+    #   # => {0=>0, 1=>1, 2=>2, 3=>3, 4=>4, 5=>5}
+    #
+    # @example UTF-8 with multibyte characters
+    #   build_byte_to_char_map("café")  # é is 2 bytes
+    #   # => {0=>0, 1=>1, 2=>2, 3=>3, 5=>4}  # Note: byte 4 is continuation byte
+    #
+    def build_byte_to_char_map(str)
+      map = {}
+      char_pos = 0
+      byte_pos = 0
+
+      # Iterate through each character (not byte) in the string
+      str.each_char do |char|
+        # Map the starting byte position of this character
+        map[byte_pos] = char_pos
+
+        # Advance byte position by the byte size of this character
+        byte_pos += char.bytesize
+        char_pos += 1
+      end
+
+      # Add final mapping for the end of the string
+      map[byte_pos] = char_pos
+      map
     end
   end
 end

--- a/spec/rhales/earliest_injection_detector_spec.rb
+++ b/spec/rhales/earliest_injection_detector_spec.rb
@@ -402,7 +402,6 @@ RSpec.describe Rhales::EarliestInjectionDetector do
         position = detector.detect(html)
         expect(position).not_to be_nil
         # Should find safe injection point after link tag
-        link_tag = html.index('<link rel="stylesheet"')
         link_end = html.index('スタイル.css">') + 'スタイル.css">'.length
         expect(position).to be >= link_end
 

--- a/spec/rhales/earliest_injection_detector_spec.rb
+++ b/spec/rhales/earliest_injection_detector_spec.rb
@@ -297,5 +297,120 @@ RSpec.describe Rhales::EarliestInjectionDetector do
         expect(end_time - start_time).to be < 0.1  # Should complete within 100ms
       end
     end
+
+    context 'with UTF-8 multibyte characters' do
+      it 'correctly handles multibyte characters in title' do
+        html = <<~HTML
+          <html>
+          <head>
+            <title>日本語タイトル</title>
+            <link rel="stylesheet" href="style.css">
+            <meta name="description" content="テスト">
+          </head>
+          <body>
+            <div id="app">コンテンツ</div>
+          </body>
+          </html>
+        HTML
+
+        position = detector.detect(html)
+        expect(position).not_to be_nil
+        # Should inject after the link tag
+        expect(position).to be > html.index('<link rel="stylesheet" href="style.css">')
+      end
+
+      it 'correctly handles multibyte characters before script tag' do
+        html = <<~HTML
+          <html>
+          <head>
+            <title>日本語</title>
+            <link rel="stylesheet" href="style.css">
+            <script>var x = 1;</script>
+          </head>
+          <body>
+            <div id="app">安全</div>
+          </body>
+          </html>
+        HTML
+
+        position = detector.detect(html)
+        expect(position).not_to be_nil
+        # Should inject after link, not inside script
+        link_end = html.index('style.css">') + 11
+        script_start = html.index('<script>')
+        expect(position).to be >= link_end
+        expect(position).to be < script_start
+      end
+
+      it 'correctly handles multibyte characters in meta tags' do
+        html = <<~HTML
+          <html>
+          <head>
+            <meta charset="UTF-8">
+            <meta name="description" content="これはテストです">
+            <meta name="keywords" content="日本語,キーワード">
+          </head>
+          <body>
+            <div id="app"></div>
+          </body>
+          </html>
+        HTML
+
+        position = detector.detect(html)
+        expect(position).not_to be_nil
+        # Should inject after the last meta tag
+        last_meta_end = html.index('content="日本語,キーワード">') + 'content="日本語,キーワード">'.length
+        expect(position).to be >= last_meta_end
+      end
+
+      it 'correctly calculates position with multibyte before body tag' do
+        html = <<~HTML
+          <html>
+          <head>
+            <title>テスト</title>
+          </head>
+          <body class="日本語-class">
+            <div id="app">コンテンツ</div>
+          </body>
+          </html>
+        HTML
+
+        position = detector.detect(html)
+        expect(position).not_to be_nil
+        # Should find a position in the head section
+        expect(position).to be < html.index('<body')
+      end
+
+      it 'handles complex multibyte scenarios with all tag types' do
+        html = <<~HTML
+          <html>
+          <head>
+            <title>日本語アプリケーション</title>
+            <link rel="stylesheet" href="スタイル.css">
+            <meta name="description" content="これは日本語のメタ情報です">
+            <script>
+            // 日本語のコメント
+            var greeting = "こんにちは";
+            </script>
+          </head>
+          <body>
+            <div id="app">アプリケーション本体</div>
+          </body>
+          </html>
+        HTML
+
+        position = detector.detect(html)
+        expect(position).not_to be_nil
+        # Should find safe injection point after link tag
+        link_tag = html.index('<link rel="stylesheet"')
+        link_end = html.index('スタイル.css">') + 'スタイル.css">'.length
+        expect(position).to be >= link_end
+
+        # Verify the position is actually safe (not inside script)
+        script_start = html.index('<script>')
+        script_end = html.index('</script>') + 9
+        expect(position).not_to be_between(script_start + 1, script_end - 1)
+      end
+    end
   end
 end

--- a/spec/rhales/safe_injection_validator_spec.rb
+++ b/spec/rhales/safe_injection_validator_spec.rb
@@ -236,4 +236,84 @@ RSpec.describe Rhales::SafeInjectionValidator do
       expect(validator.safe_injection_point?(whitespace_pos)).to be true
     end
   end
+
+  describe 'UTF-8 multibyte character handling' do
+    it 'correctly handles multibyte UTF-8 characters in title tags' do
+      html = '<head><title>日本語タイトル</title></head><body>Content</body>'
+      validator = described_class.new(html)
+
+      # The bug: StringScanner.pos returns byte position, but String#[] uses char position
+      # "日本語タイトル" is 7 characters but 21 bytes (3 bytes per character)
+      # When scanner is positioned after </title>, it returns byte position
+      # but String#[] indexing uses character positions
+
+      # Position after </title> tag should be safe
+      title_close_pos = html.index('</title>') + 8  # Character position
+      expect(validator.safe_injection_point?(title_close_pos)).to be true
+
+      # Position inside title should be unsafe (CDATA-like content)
+      # Actually, title tags are not in UNSAFE_CONTEXTS, so this should be safe
+      title_start_pos = html.index('日本語')
+      expect(validator.safe_injection_point?(title_start_pos)).to be true
+
+      # Position after </head> should definitely be safe
+      head_close_pos = html.index('</head>') + 7
+      expect(validator.safe_injection_point?(head_close_pos)).to be true
+
+      # Position at <body> tag should be safe
+      body_pos = html.index('<body>')
+      expect(validator.safe_injection_point?(body_pos)).to be true
+    end
+
+    it 'correctly handles multibyte UTF-8 characters with script tags' do
+      html = '<head><title>日本語</title></head><script>var x = 1;</script><body>コンテンツ</body>'
+      validator = described_class.new(html)
+
+      # Position inside script should be unsafe
+      script_inside = html.index('var x')
+      expect(validator.safe_injection_point?(script_inside)).to be false
+
+      # Position after script should be safe
+      # Bug manifests here: if byte positions used, this could point to wrong location
+      body_tag = html.index('<body>')
+      expect(validator.safe_injection_point?(body_tag)).to be true
+    end
+
+    it 'correctly calculates unsafe ranges with multibyte characters before script' do
+      html = '<div>日本語テキスト</div><script>alert("test");</script><div>After</div>'
+      validator = described_class.new(html)
+
+      # Inside script should be unsafe
+      alert_pos = html.index('alert')
+      expect(validator.safe_injection_point?(alert_pos)).to be false
+
+      # After script should be safe
+      after_div = html.index('<div>After</div>')
+      expect(validator.safe_injection_point?(after_div)).to be true
+
+      # Before script should be safe
+      japanese_div = html.index('<div>日本語')
+      expect(validator.safe_injection_point?(japanese_div)).to be true
+    end
+
+    it 'correctly finds nearest safe point with multibyte characters' do
+      html = '<div>テスト</div><script>unsafe</script><div>安全</div>'
+      validator = described_class.new(html)
+
+      # From inside script, find safe point before
+      unsafe_pos = html.index('unsafe')
+      safe_before = validator.nearest_safe_point_before(unsafe_pos)
+      expect(safe_before).not_to be_nil
+      expect(validator.safe_injection_point?(safe_before)).to be true
+
+      # From inside script, find safe point after
+      safe_after = validator.nearest_safe_point_after(unsafe_pos)
+      expect(safe_after).not_to be_nil
+      expect(validator.safe_injection_point?(safe_after)).to be true
+
+      # Verify the safe points are actually at correct positions
+      # safe_after should be after </script>
+      expect(safe_after).to be > html.index('</script>')
+    end
+  end
 end


### PR DESCRIPTION
## Problem

Rhales's hydration injection system was mixing byte positions from `StringScanner.pos` with character-based string operations (`String#[]`). When HTML templates contained multibyte UTF-8 characters (Japanese: 日本語, emoji, etc.), the injection point calculations were incorrect, causing hydration scripts to be inserted mid-attribute or in wrong locations, corrupting the rendered HTML.

**Root cause**: Multibyte UTF-8 characters use multiple bytes per character (Japanese = 3 bytes/char). StringScanner reports byte offsets, but Ruby's string indexing expects character positions. For example, the string "日本語タイトル" is 7 characters but 21 bytes - when scanner reports position 73 (bytes), using `html[73]` actually indexes character position 73, pointing to the wrong location in HTML with multibyte content.

## Solution

Convert all byte positions from StringScanner to character positions using `byteslice` before using them with string indexing:

```ruby
# Before (buggy)
body_start = scanner.pos - scanner.matched.length

# After (fixed)  
byte_body_start = scanner.pos - scanner.matched.length
body_start = template_html.byteslice(0, byte_body_start).length
```

The `byteslice(0, n).length` pattern extracts the first n bytes and counts the characters, converting byte offsets to character positions.

## Changes

**SafeInjectionValidator** - Fixed unsafe range detection with multibyte content
- Convert scanner byte positions when building unsafe context ranges (scripts, styles, comments)

**EarliestInjectionDetector** - Fixed injection point calculation  
- Convert byte positions for body, head, link, meta, and script tag boundaries
- Applied to all 5 scanning methods that locate injection points

**Test coverage** - Added comprehensive UTF-8 test suite
- 9 new test cases covering title, link, meta, script, and body tags with Japanese characters
- Tests verify correct position calculation with mixed multibyte content
- Validates that injection points remain safe regardless of character encoding

## Impact

Fixes HTML corruption in templates containing CJK characters (Chinese, Japanese, Korean), emoji, or any multibyte UTF-8 content. No breaking changes - ASCII HTML behavior unchanged. The fix ensures correct hydration script injection for all Unicode scripts.