### PR TITLE
Add external schema references via src attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-03-21
+
 ### Added
 - **External Schema References**: Schema definitions can now reference external TypeScript/JavaScript files via the `src` attribute
   - Enables single-source-of-truth patterns where TypeScript schemas drive both frontend types and Rhales validation
   - Path resolution relative to template file with security checks to prevent path traversal
   - Rake task output now shows inline vs external schema sources
   - Example: `<schema src="schemas/user.schema.ts" lang="js-zod" window="__USER__">`
+- **Multi-directory Schema Search**: New `schema_search_paths` configuration option
+  - Allows searching multiple directories for external schema files
+  - Resolution order: template-relative first, then search paths in order
+  - Security checks apply to all configured paths
+- **tsx Import Mode**: New bundling mode for external schemas with imports
+  - `schema_use_tsx_import = true` enables esbuild bundling
+  - `schema_tsconfig_path` allows custom TypeScript configuration
+  - Externalizes zod to prevent dual-instance issues
+  - Cross-platform file:// URL support for Windows ESM compatibility
+
+### Changed
+- **Ruby 3.4+ required** (was 3.3.4)
+- Updated zod to 4.3.6
+- Relaxed json_schemer dependency from ~> 2.3 to ~> 2
+
+### Removed
+- Unused `HydrationRegistry.clear!` method
 - **Production Logging**: Structured logging via `Rhales.logger=` for security auditing and debugging
   - View rendering events with template details, timing, and hydration size
   - Schema validation warnings for production debugging (missing/extra keys)
@@ -37,7 +56,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - All merge operations happen client-side after server-side interpolation and JSON serialization
 - Request-scoped registry prevents cross-request data leakage
 
-## [0.1.0] - 2024-01-XX
+## [0.1.0] - 2025-07-21
 
 ### Added
 - Initial release of Rhales

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **External Schema References**: Schema definitions can now reference external TypeScript/JavaScript files via the `src` attribute
+  - Enables single-source-of-truth patterns where TypeScript schemas drive both frontend types and Rhales validation
+  - Path resolution relative to template file with security checks to prevent path traversal
+  - Rake task output now shows inline vs external schema sources
+  - Example: `<schema src="schemas/user.schema.ts" lang="js-zod" window="__USER__">`
 - **Production Logging**: Structured logging via `Rhales.logger=` for security auditing and debugging
   - View rendering events with template details, timing, and hydration size
   - Schema validation warnings for production debugging (missing/extra keys)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,14 +24,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - `schema_tsconfig_path` allows custom TypeScript configuration
   - Externalizes zod to prevent dual-instance issues
   - Cross-platform file:// URL support for Windows ESM compatibility
-
-### Changed
-- **Ruby 3.4+ required** (was 3.3.4)
-- Updated zod to 4.3.6
-- Relaxed json_schemer dependency from ~> 2.3 to ~> 2
-
-### Removed
-- Unused `HydrationRegistry.clear!` method
 - **Production Logging**: Structured logging via `Rhales.logger=` for security auditing and debugging
   - View rendering events with template details, timing, and hydration size
   - Schema validation warnings for production debugging (missing/extra keys)
@@ -47,9 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for collision detection and merge strategies
 
 ### Changed
+- **Ruby 3.4+ required** (was 3.3.4)
+- Updated zod to 4.3.6
+- Relaxed json_schemer dependency from ~> 2.3 to ~> 2
 - Replaced `json-schema` gem with `json_schemer` for better JSON Schema Draft 2020-12 support
 - Improved validation error messages with more structured output from json_schemer
 - Validation performance improved to <0.05ms average (was ~2ms with json-schema)
+
+### Removed
+- Unused `HydrationRegistry.clear!` method
 
 ### Security
 - Window collision detection prevents accidental data exposure by making overwrites explicit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Comprehensive test coverage for collision detection and merge strategies
 
 ### Changed
-- **Ruby 3.4+ required** (was 3.3.4)
+- **Ruby 3.4+ required** (was 3.3.4) - aligns with current LTS ecosystem; no Ruby 3.3 features relied upon, but 3.4 is recommended for YJIT improvements and json_schemer performance
 - Updated zod to 4.3.6
 - Relaxed json_schemer dependency from ~> 2.3 to ~> 2
 - Replaced `json-schema` gem with `json_schemer` for better JSON Schema Draft 2020-12 support

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     rhales (0.6.0)
-      json_schemer (~> 2.3)
+      json_schemer (~> 2)
       logger
       tilt (~> 2)
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rhales (0.5.3)
+    rhales (0.6.0)
       json_schemer (~> 2.3)
       logger
       tilt (~> 2)

--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # Rhales - Ruby Single File Components
 
 > [!CAUTION]
-> **Early Development Release** - Rhales is in active development (v0.5). The API underwent breaking changes from v0.4. While functional and tested, it's recommended for experimental use and contributions. Please report issues and provide feedback through GitHub.
+> **Early Development Release** - Rhales is in active development (v0.6). The API underwent breaking changes from v0.4. While functional and tested, it's recommended for experimental use and contributions. Please report issues and provide feedback through GitHub.
 
 Rhales is a **type-safe contract enforcement framework** for server-rendered pages with client-side data hydration. It uses `.rue` files (Ruby Single File Components) that combine Zod v4 schemas, Handlebars templates, and documentation into a single contract-first format.
 
 **About the name:** It all started with a simple mustache template many years ago. Mustache's successor, "Handlebars," is a visual analog for a mustache. "Two Whales Kissing" is another visual analog for a mustache, and since we're working with Ruby, we call it "Rhales" (Ruby + Whales). It's a perfect name with absolutely no ambiguity or risk of confusion.
 
-## What's New in v0.5
+## What's New in v0.6
 
-- ✅ **Schema-First Design**: Replaced `<data>` sections with Zod v4 `<schema>` sections
-- ✅ **Type Safety**: Contract enforcement between backend and frontend
-- ✅ **Simplified API**: Removed deprecated parameters (`sess`, `cust`, `props:`, `app_data:`)
-- ✅ **Clear Context Layers**: Renamed `app` → `request` for clarity
-- ✅ **Schema Tooling**: Rake tasks for schema generation and validation
-- ✅ **100% Migration**: All demo templates use schemas
+- ✅ **External Schema References**: Reference TypeScript schema files via `src` attribute for single-source-of-truth patterns
+- ✅ **Multi-directory Search**: Configure `schema_search_paths` to search multiple directories for shared schemas
+- ✅ **tsx Import Mode**: Bundle external schemas with imports via esbuild (`schema_use_tsx_import`)
+- ✅ **Ruby 3.4+ Required**: Updated minimum Ruby version
+
+**v0.5 features:** Schema-first design, type safety, simplified API, clear context layers, schema tooling.
 
 **Breaking changes from v0.4:** See [Migration Guide](#migration-from-v04-to-v05) below.
 
@@ -168,6 +168,31 @@ export default schema;
 ```
 
 The `src` path is resolved relative to the template file. Security checks prevent path traversal outside the templates directory.
+
+#### Multi-directory Search
+
+Configure additional directories to search for shared schema files:
+
+```ruby
+Rhales.configure do |config|
+  config.schema_search_paths = ['./shared/schemas', './lib/schemas']
+end
+```
+
+Resolution order: template-relative first, then search paths in order.
+
+#### tsx Import Mode
+
+For external schemas that import other modules, enable esbuild bundling:
+
+```ruby
+Rhales.configure do |config|
+  config.schema_use_tsx_import = true
+  config.schema_tsconfig_path = './tsconfig.json'  # optional
+end
+```
+
+This bundles the schema with all its imports while externalizing zod to prevent dual-instance issues.
 
 ### Zod Schema Examples
 

--- a/README.md
+++ b/README.md
@@ -134,6 +134,40 @@ const schema = z.object({
 | `version` | No | Schema version | `"2"` |
 | `envelope` | No | Response wrapper type | `"SuccessEnvelope"` |
 | `layout` | No | Layout template reference | `"layouts/main"` |
+| `src` | No | External schema file path | `"schemas/user.schema.ts"` |
+
+### External Schema References
+
+Instead of defining schemas inline, you can reference external TypeScript/JavaScript files. This enables single-source-of-truth patterns where the same schema file drives both frontend TypeScript types (via `z.infer<>`) and Rhales validation.
+
+```xml
+<!-- templates/dashboard.rue -->
+<schema src="schemas/dashboard.schema.ts" lang="js-zod" window="__DASHBOARD__">
+</schema>
+
+<template>
+  <div>{{user.name}}</div>
+</template>
+```
+
+```typescript
+// templates/schemas/dashboard.schema.ts
+import { z } from 'zod';
+
+const schema = z.object({
+  user: z.object({
+    name: z.string(),
+    email: z.string().email()
+  }),
+  items: z.array(z.string())
+});
+
+export default schema;
+
+// TypeScript frontend can import and use: z.infer<typeof schema>
+```
+
+The `src` path is resolved relative to the template file. Security checks prevent path traversal outside the templates directory.
 
 ### Zod Schema Examples
 

--- a/lib/rhales/configuration.rb
+++ b/lib/rhales/configuration.rb
@@ -277,6 +277,7 @@ module Rhales
     def freeze!
       @features.freeze
       @template_paths.freeze
+      @schema_search_paths.freeze
       freeze
     end
 

--- a/lib/rhales/configuration.rb
+++ b/lib/rhales/configuration.rb
@@ -157,6 +157,9 @@ module Rhales
     # Hydration mismatch reporting settings
     attr_accessor :hydration_mismatch_format, :hydration_authority
 
+    # External schema settings
+    attr_accessor :schema_search_paths, :schema_tsconfig_path, :schema_use_tsx_import
+
     def initialize
       # Set sensible defaults
       @default_locale         = 'en'
@@ -190,6 +193,11 @@ module Rhales
       # Hydration mismatch reporting defaults
       @hydration_mismatch_format        = :compact  # :compact, :multiline, :sidebyside, :json
       @hydration_authority              = :schema   # :schema or :data
+
+      # External schema defaults
+      @schema_search_paths              = []        # Additional paths to search for external schemas
+      @schema_tsconfig_path             = nil       # Path to tsconfig.json for tsx import execution
+      @schema_use_tsx_import            = false     # Use tsx import (runs through project tsconfig)
 
       # Yield to block for configuration if provided
       yield(self) if block_given?

--- a/lib/rhales/configuration.rb
+++ b/lib/rhales/configuration.rb
@@ -265,6 +265,13 @@ module Rhales
         end
       end
 
+      # Validate schema search paths exist if specified
+      @schema_search_paths.each do |path|
+        unless Dir.exist?(path)
+          errors << "Schema search path does not exist: #{path}"
+        end
+      end
+
       # Validate cache TTL
       if @cache_ttl && @cache_ttl <= 0
         errors << 'cache_ttl must be positive'

--- a/lib/rhales/core/rue_document.rb
+++ b/lib/rhales/core/rue_document.rb
@@ -39,7 +39,7 @@ module Rhales
     ALL_SECTIONS = KNOWN_SECTIONS.freeze
 
     # Known schema section attributes
-    KNOWN_SCHEMA_ATTRIBUTES = %w[lang version envelope window merge layout extends].freeze
+    KNOWN_SCHEMA_ATTRIBUTES = %w[lang version envelope window merge layout extends src].freeze
 
     attr_reader :content, :file_path, :grammar, :ast
 
@@ -149,6 +149,12 @@ module Rhales
 
     def schema_extends
       schema_attributes['extends']
+    end
+
+    # External schema file reference (optional)
+    # When present, schema code is loaded from this path instead of inline content
+    def schema_src
+      schema_attributes['src']
     end
 
     def section?(name)

--- a/lib/rhales/hydration/hydration_registry.rb
+++ b/lib/rhales/hydration/hydration_registry.rb
@@ -27,10 +27,6 @@ module Rhales
         }
       end
 
-      def clear!
-        Thread.current[:rhales_hydration_registry] = {}
-      end
-
       # Expose registry for testing purposes
       def registry
         thread_local_registry

--- a/lib/rhales/utils/schema_extractor.rb
+++ b/lib/rhales/utils/schema_extractor.rb
@@ -160,6 +160,7 @@ module Rhales
     def resolve_schema_src_path(template_path, src)
       template_dir = File.dirname(template_path)
       resolved = File.expand_path(src, template_dir)
+      searched_paths = [resolved]
 
       # First, check if the path exists relative to template
       if File.exist?(resolved) && path_within_allowed_directories?(resolved)
@@ -172,20 +173,22 @@ module Rhales
       search_paths.each do |search_path|
         expanded_search_path = File.expand_path(search_path)
         candidate = File.join(expanded_search_path, src)
+        searched_paths << candidate
 
         if File.exist?(candidate) && path_within_allowed_directories?(candidate)
           return candidate
         end
       end
 
-      # If we get here, the path was resolved relative to template but may not exist yet
-      # (e.g., during validation). Apply security check to the original resolution.
+      # Security check on the template-relative path
       unless path_within_allowed_directories?(resolved)
         raise ExtractionError,
               "Schema src path traversal not allowed: '#{src}' resolves outside allowed directories"
       end
 
-      resolved
+      # File not found in any location - raise helpful error listing all searched paths
+      raise ExtractionError,
+            "Schema file not found: '#{src}'. Searched:\n  - #{searched_paths.join("\n  - ")}"
     end
 
     # Check if a path is within any allowed directory

--- a/lib/rhales/utils/schema_extractor.rb
+++ b/lib/rhales/utils/schema_extractor.rb
@@ -147,7 +147,11 @@ module Rhales
       relative_path.to_s.sub(/\.rue$/, '')
     end
 
-    # Resolve external schema src path relative to template file
+    # Resolve external schema src path
+    #
+    # Resolution order:
+    # 1. Relative to template file directory
+    # 2. Search through configured schema_search_paths
     #
     # @param template_path [String] Absolute path to the .rue template
     # @param src [String] The src attribute value from the schema tag
@@ -157,13 +161,49 @@ module Rhales
       template_dir = File.dirname(template_path)
       resolved = File.expand_path(src, template_dir)
 
-      # Security: Ensure resolved path is within templates directory
-      unless path_within_directory?(resolved, @templates_dir)
+      # First, check if the path exists relative to template
+      if File.exist?(resolved) && path_within_allowed_directories?(resolved)
+        return resolved
+      end
+
+      # If the relative path does not exist or is not allowed,
+      # search through configured schema_search_paths
+      search_paths = Rhales.configuration.schema_search_paths || []
+      search_paths.each do |search_path|
+        expanded_search_path = File.expand_path(search_path)
+        candidate = File.join(expanded_search_path, src)
+
+        if File.exist?(candidate) && path_within_allowed_directories?(candidate)
+          return candidate
+        end
+      end
+
+      # If we get here, the path was resolved relative to template but may not exist yet
+      # (e.g., during validation). Apply security check to the original resolution.
+      unless path_within_allowed_directories?(resolved)
         raise ExtractionError,
-              "Schema src path traversal not allowed: '#{src}' resolves outside templates directory"
+              "Schema src path traversal not allowed: '#{src}' resolves outside allowed directories"
       end
 
       resolved
+    end
+
+    # Check if a path is within any allowed directory
+    #
+    # Allowed directories include:
+    # - The templates directory
+    # - Any configured schema_search_paths
+    #
+    # @param path [String] Path to check
+    # @return [Boolean] True if path is within an allowed directory
+    def path_within_allowed_directories?(path)
+      return true if path_within_directory?(path, @templates_dir)
+
+      search_paths = Rhales.configuration.schema_search_paths || []
+      search_paths.any? do |search_path|
+        expanded_search_path = File.expand_path(search_path)
+        path_within_directory?(path, expanded_search_path)
+      end
     end
 
     # Read schema content from external file

--- a/lib/rhales/utils/schema_extractor.rb
+++ b/lib/rhales/utils/schema_extractor.rb
@@ -71,7 +71,18 @@ module Rhales
       return nil unless doc.section?('schema')
 
       template_name = derive_template_name(file_path)
-      schema_code = doc.section('schema')
+      src = doc.schema_src
+      resolved_path = nil
+      schema_code = nil
+
+      if src
+        # External schema: resolve path and read content
+        resolved_path = resolve_schema_src_path(file_path, src)
+        schema_code = read_schema_from_src(resolved_path, src, template_name)
+      else
+        # Inline schema: use content from the schema section
+        schema_code = doc.section('schema')
+      end
 
       {
         template_name: template_name,
@@ -83,7 +94,9 @@ module Rhales
         window: doc.schema_window,
         merge: doc.schema_merge_strategy,
         layout: doc.schema_layout,
-        extends: doc.schema_extends
+        extends: doc.schema_extends,
+        src: src,
+        resolved_path: resolved_path
       }
     end
 
@@ -97,15 +110,20 @@ module Rhales
 
     # Count how many .rue files have schema sections
     #
-    # @return [Hash] Count information
+    # @return [Hash] Count information including external vs inline breakdown
     def schema_stats
       all_files = find_rue_files
       schemas = extract_all
+
+      external_count = schemas.count { |s| s[:src] }
+      inline_count = schemas.count { |s| s[:src].nil? }
 
       {
         total_files: all_files.count,
         files_with_schemas: schemas.count,
         files_without_schemas: all_files.count - schemas.count,
+        external_schemas: external_count,
+        inline_schemas: inline_count,
         schemas_by_lang: schemas.group_by { |s| s[:lang] }.transform_values(&:count)
       }
     end
@@ -127,6 +145,63 @@ module Rhales
       file_pathname = Pathname.new(file_path)
       relative_path = file_pathname.relative_path_from(templates_pathname)
       relative_path.to_s.sub(/\.rue$/, '')
+    end
+
+    # Resolve external schema src path relative to template file
+    #
+    # @param template_path [String] Absolute path to the .rue template
+    # @param src [String] The src attribute value from the schema tag
+    # @return [String] Absolute path to the external schema file
+    # @raise [ExtractionError] If path traversal is detected or file not found
+    def resolve_schema_src_path(template_path, src)
+      template_dir = File.dirname(template_path)
+      resolved = File.expand_path(src, template_dir)
+
+      # Security: Ensure resolved path is within templates directory
+      unless path_within_directory?(resolved, @templates_dir)
+        raise ExtractionError,
+              "Schema src path traversal not allowed: '#{src}' resolves outside templates directory"
+      end
+
+      resolved
+    end
+
+    # Read schema content from external file
+    #
+    # @param resolved_path [String] Absolute path to the schema file
+    # @param src [String] Original src attribute value (for error messages)
+    # @param template_name [String] Template name (for error messages)
+    # @return [String] Schema file content
+    # @raise [ExtractionError] If file cannot be read
+    def read_schema_from_src(resolved_path, src, template_name)
+      unless File.exist?(resolved_path)
+        raise ExtractionError,
+              "External schema file not found: '#{src}' (resolved to: #{resolved_path}) " \
+              "referenced by template '#{template_name}'"
+      end
+
+      File.read(resolved_path)
+    rescue Errno::EACCES => e
+      raise ExtractionError,
+            "Permission denied reading external schema '#{src}': #{e.message}"
+    rescue Errno::EISDIR
+      raise ExtractionError,
+            "External schema path '#{src}' is a directory, not a file"
+    end
+
+    # Check if a path is within a given directory (security check)
+    #
+    # @param path [String] Path to check
+    # @param directory [String] Directory that should contain the path
+    # @return [Boolean] True if path is within directory
+    def path_within_directory?(path, directory)
+      expanded_path = File.expand_path(path)
+      expanded_dir = File.expand_path(directory)
+
+      # Ensure directory ends with separator for accurate prefix matching
+      expanded_dir_with_sep = expanded_dir.end_with?(File::SEPARATOR) ? expanded_dir : "#{expanded_dir}#{File::SEPARATOR}"
+
+      expanded_path.start_with?(expanded_dir_with_sep) || expanded_path == expanded_dir
     end
   end
 end

--- a/lib/rhales/utils/schema_generator.rb
+++ b/lib/rhales/utils/schema_generator.rb
@@ -3,6 +3,7 @@
 # frozen_string_literal: true
 
 require 'open3'
+require 'securerandom'
 require 'tempfile'
 require 'fileutils'
 require_relative 'schema_extractor'
@@ -154,8 +155,13 @@ module Rhales
     def execute_tsx(script_path)
       tsconfig_path = Rhales.configuration.schema_tsconfig_path
 
-      if tsconfig_path && File.exist?(tsconfig_path)
-        Open3.capture3('pnpm', 'exec', 'tsx', '--tsconfig', tsconfig_path, script_path)
+      if tsconfig_path
+        if File.exist?(tsconfig_path)
+          Open3.capture3('pnpm', 'exec', 'tsx', '--tsconfig', tsconfig_path, script_path)
+        else
+          warn "[Rhales] Warning: schema_tsconfig_path '#{tsconfig_path}' does not exist, ignoring"
+          Open3.capture3('pnpm', 'exec', 'tsx', script_path)
+        end
       else
         Open3.capture3('pnpm', 'exec', 'tsx', script_path)
       end
@@ -178,13 +184,16 @@ module Rhales
       schema_path = schema_info[:resolved_path]
 
       # Bundle external schema with esbuild to temp file - resolves all imports
+      # Use SecureRandom for uniqueness across concurrent invocations
       temp_dir = File.join(Dir.pwd, 'tmp')
       FileUtils.mkdir_p(temp_dir) unless Dir.exist?(temp_dir)
-      bundled_file = File.join(temp_dir, "bundled_#{File.basename(schema_path, '.*')}_#{Process.pid}.mjs")
+      unique_suffix = "#{Process.pid}_#{SecureRandom.hex(4)}"
+      bundled_file = File.join(temp_dir, "bundled_#{File.basename(schema_path, '.*')}_#{unique_suffix}.mjs")
 
       stdout, stderr, status = Open3.capture3(
         'pnpm', 'exec', 'esbuild', schema_path,
         '--bundle', '--format=esm', '--platform=node',
+        '--external:zod',
         "--outfile=#{bundled_file}"
       )
 
@@ -192,11 +201,14 @@ module Rhales
         raise GenerationError, "esbuild bundling failed for #{schema_path}: #{stderr}"
       end
 
+      # Convert to file:// URL for cross-platform ESM import compatibility
+      bundled_file_url = path_to_file_url(bundled_file)
+
       script = <<~TYPESCRIPT
         // Auto-generated schema generator for #{safe_name}
         // Source: #{schema_info[:src]} (bundled via esbuild)
         import { z } from 'zod/v4';
-        import schema from '#{bundled_file}';
+        import schema from '#{bundled_file_url}';
 
         // Generate JSON Schema
         try {
@@ -308,6 +320,22 @@ module Rhales
 
     def ensure_output_directory!
       FileUtils.mkdir_p(@output_dir) unless File.directory?(@output_dir)
+    end
+
+    # Convert absolute path to file:// URL for cross-platform ESM imports
+    #
+    # On Windows, paths like C:\foo\bar need to become file:///C:/foo/bar
+    # On Unix, paths like /foo/bar become file:///foo/bar
+    #
+    # @param path [String] Absolute file path
+    # @return [String] file:// URL
+    def path_to_file_url(path)
+      normalized = path.tr('\\', '/')
+      if normalized.match?(%r{^[A-Za-z]:}) # Windows drive letter
+        "file:///#{normalized}"
+      else
+        "file://#{normalized}"
+      end
     end
   end
 end

--- a/lib/rhales/utils/schema_generator.rb
+++ b/lib/rhales/utils/schema_generator.rb
@@ -76,7 +76,8 @@ module Rhales
         rescue => e
           results[:failed] += 1
           results[:success] = false
-          error_msg = "Failed to generate schema for #{schema_info[:template_name]}: #{e.message}"
+          source_info = schema_info[:src] ? " (from #{schema_info[:src]})" : ""
+          error_msg = "Failed to generate schema for #{schema_info[:template_name]}#{source_info}: #{e.message}"
           results[:errors] << error_msg
           warn error_msg
         end
@@ -125,9 +126,15 @@ module Rhales
     def build_typescript_script(schema_info)
       # Escape single quotes in template name for TypeScript string
       safe_name = schema_info[:template_name].gsub("'", "\\'")
+      source_comment = if schema_info[:src]
+        "// Source: #{schema_info[:src]} (external)"
+      else
+        "// Source: inline schema"
+      end
 
       <<~TYPESCRIPT
         // Auto-generated schema generator for #{safe_name}
+        #{source_comment}
         import { z } from 'zod/v4';
 
         // Schema code from .rue template

--- a/lib/rhales/utils/schema_generator.rb
+++ b/lib/rhales/utils/schema_generator.rb
@@ -96,14 +96,20 @@ module Rhales
       FileUtils.mkdir_p(temp_dir) unless Dir.exist?(temp_dir)
 
       temp_file = Tempfile.new(['schema', '.mts'], temp_dir)
+      bundled_file = nil
 
       begin
-        # Write TypeScript script
-        temp_file.write(build_typescript_script(schema_info))
+        # Write TypeScript script - use import mode for external schemas when configured
+        if use_tsx_import_mode?(schema_info)
+          script, bundled_file = build_typescript_import_script(schema_info)
+        else
+          script = build_typescript_script(schema_info)
+        end
+        temp_file.write(script)
         temp_file.close
 
-        # Execute with tsx via pnpm
-        stdout, stderr, status = Open3.capture3('pnpm', 'exec', 'tsx', temp_file.path)
+        # Execute with tsx via pnpm, optionally with tsconfig
+        stdout, stderr, status = execute_tsx(temp_file.path)
 
         unless status.success?
           raise GenerationError, "TypeScript execution failed: #{stderr}"
@@ -118,10 +124,108 @@ module Rhales
         json_schema
       ensure
         temp_file.unlink if temp_file
+        File.unlink(bundled_file) if bundled_file && File.exist?(bundled_file)
       end
     end
 
     private
+
+    # Determine if we should use tsx import mode for this schema
+    #
+    # Import mode is used when:
+    # 1. schema_use_tsx_import is enabled in configuration
+    # 2. The schema has an external src (not inline)
+    # 3. The resolved_path exists
+    #
+    # @param schema_info [Hash] Schema information
+    # @return [Boolean]
+    def use_tsx_import_mode?(schema_info)
+      return false unless Rhales.configuration.schema_use_tsx_import
+      return false unless schema_info[:src]
+      return false unless schema_info[:resolved_path]
+
+      File.exist?(schema_info[:resolved_path])
+    end
+
+    # Execute tsx with optional tsconfig
+    #
+    # @param script_path [String] Path to the TypeScript script to execute
+    # @return [Array] stdout, stderr, status from Open3.capture3
+    def execute_tsx(script_path)
+      tsconfig_path = Rhales.configuration.schema_tsconfig_path
+
+      if tsconfig_path && File.exist?(tsconfig_path)
+        Open3.capture3('pnpm', 'exec', 'tsx', '--tsconfig', tsconfig_path, script_path)
+      else
+        Open3.capture3('pnpm', 'exec', 'tsx', script_path)
+      end
+    end
+
+    # Build TypeScript script from bundled external schema
+    #
+    # Uses esbuild to bundle the external schema with all imports resolved,
+    # writes to a temp file, then imports via default export. This allows
+    # external files to name their schema variable anything they want.
+    #
+    # External schema files must use default export:
+    #   const mySchema = z.object({ ... });
+    #   export default mySchema;
+    #
+    # @param schema_info [Hash] Schema information with resolved_path
+    # @return [Array<String, String>] [script content, bundled_file_path] - caller must clean up bundled file
+    def build_typescript_import_script(schema_info)
+      safe_name = schema_info[:template_name].gsub("'", "\\'")
+      schema_path = schema_info[:resolved_path]
+
+      # Bundle external schema with esbuild to temp file - resolves all imports
+      temp_dir = File.join(Dir.pwd, 'tmp')
+      FileUtils.mkdir_p(temp_dir) unless Dir.exist?(temp_dir)
+      bundled_file = File.join(temp_dir, "bundled_#{File.basename(schema_path, '.*')}_#{Process.pid}.mjs")
+
+      stdout, stderr, status = Open3.capture3(
+        'pnpm', 'exec', 'esbuild', schema_path,
+        '--bundle', '--format=esm', '--platform=node',
+        "--outfile=#{bundled_file}"
+      )
+
+      unless status.success?
+        raise GenerationError, "esbuild bundling failed for #{schema_path}: #{stderr}"
+      end
+
+      script = <<~TYPESCRIPT
+        // Auto-generated schema generator for #{safe_name}
+        // Source: #{schema_info[:src]} (bundled via esbuild)
+        import { z } from 'zod/v4';
+        import schema from '#{bundled_file}';
+
+        // Generate JSON Schema
+        try {
+          const jsonSchema = z.toJSONSchema(schema, {
+            target: 'draft-2020-12',
+            unrepresentable: 'any',
+            cycles: 'ref',
+            reused: 'inline',
+          });
+
+          // Add metadata
+          const schemaWithMeta = {
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            $id: `https://rhales.dev/schemas/#{safe_name}.json`,
+            title: '#{safe_name}',
+            description: 'Schema for #{safe_name} template',
+            ...jsonSchema,
+          };
+
+          // Output JSON to stdout
+          console.log(JSON.stringify(schemaWithMeta, null, 2));
+        } catch (error) {
+          console.error('Schema generation error:', error.message);
+          process.exit(1);
+        }
+      TYPESCRIPT
+
+      [script, bundled_file]
+    end
 
     def build_typescript_script(schema_info)
       # Escape single quotes in template name for TypeScript string
@@ -191,6 +295,14 @@ module Rhales
       stdout, stderr, status = Open3.capture3('pnpm', 'exec', 'tsx', '--version')
       unless status.success?
         raise GenerationError, "tsx not found. Run: pnpm install tsx --save-dev"
+      end
+
+      # Check esbuild is available when tsx import mode is enabled
+      if Rhales.configuration.schema_use_tsx_import
+        stdout, stderr, status = Open3.capture3('pnpm', 'exec', 'esbuild', '--version')
+        unless status.success?
+          raise GenerationError, "esbuild not found (required for external schema bundling). Run: pnpm install esbuild --save-dev"
+        end
       end
     end
 

--- a/lib/rhales/version.rb
+++ b/lib/rhales/version.rb
@@ -5,6 +5,6 @@
 module Rhales
   # Version information for the RSFC gem
   unless defined?(Rhales::VERSION)
-    VERSION = '0.5.3'
+    VERSION = '0.6.0'
   end
 end

--- a/lib/tasks/rhales_schema.rake
+++ b/lib/tasks/rhales_schema.rake
@@ -45,7 +45,8 @@ namespace :rhales do
 
       puts "Found #{schemas.size} schema section(s):"
       schemas.each do |schema|
-        puts "  - #{schema[:template_name]} (#{schema[:lang]})"
+        source_type = schema[:src] ? "external: #{schema[:src]}" : "inline"
+        puts "  - #{schema[:template_name]} (#{schema[:lang]}, #{source_type})"
       end
       puts
 
@@ -185,6 +186,13 @@ namespace :rhales do
       puts "Files with <schema>: #{stats[:files_with_schemas]}"
       puts "Files without <schema>: #{stats[:files_without_schemas]}"
       puts
+
+      if stats[:files_with_schemas] > 0
+        puts "Schema sources:"
+        puts "  External (src attribute): #{stats[:external_schemas]}"
+        puts "  Inline: #{stats[:inline_schemas]}"
+        puts
+      end
 
       if stats[:schemas_by_lang].any?
         puts "By language:"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "type": "module",
   "dependencies": {
-    "zod": "^4.1.12"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@prettier/plugin-ruby": "^4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       zod:
-        specifier: ^4.1.12
-        version: 4.1.12
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@prettier/plugin-ruby':
         specifier: ^4.0.4
@@ -208,8 +208,8 @@ packages:
     engines: {node: '>=18.0.0'}
     hasBin: true
 
-  zod@4.1.12:
-    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -342,4 +342,4 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.3
 
-  zod@4.1.12: {}
+  zod@4.3.6: {}

--- a/rhales.gemspec
+++ b/rhales.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.homepage              = 'https://github.com/onetimesecret/rhales'
   spec.license               = 'MIT'
-  spec.required_ruby_version = '>= 3.3.4'
+  spec.required_ruby_version = '>= 3.4'
 
   spec.metadata['source_code_uri']       = 'https://github.com/onetimesecret/rhales'
   spec.metadata['changelog_uri']         = 'https://github.com/onetimesecret/rhales/blob/main/CHANGELOG.md'
@@ -41,13 +41,10 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   # Runtime dependencies
-  spec.add_dependency 'json_schemer', '~> 2.3'  # JSON Schema validation in middleware
+
+  spec.add_dependency 'json_schemer', '~> 2'    # JSON Schema validation in middleware
   spec.add_dependency 'logger'                  # Standard library logger for logging support
   spec.add_dependency 'tilt', '~> 2'            # Templating engine for rendering RSFCs
-
-  # Optional dependencies for performance optimization
-  # Install oj for 10-20x faster JSON parsing and 5-10x faster generation
-  # spec.add_dependency 'oj', '~> 3.13'
 
   # Development dependencies should be specified in Gemfile instead of gemspec
   # See: https://bundler.io/guides/creating_gem.html#testing-our-gem

--- a/spec/fixtures/templates/schema_test/external_schema.rue
+++ b/spec/fixtures/templates/schema_test/external_schema.rue
@@ -1,0 +1,6 @@
+<schema src="schemas/bootstrap.schema.ts" lang="js-zod" window="__BOOTSTRAP__">
+</schema>
+
+<template>
+  <div>{{appName}}</div>
+</template>

--- a/spec/fixtures/templates/schema_test/external_schema_js.rue
+++ b/spec/fixtures/templates/schema_test/external_schema_js.rue
@@ -1,0 +1,6 @@
+<schema src="schemas/user.schema.js" lang="js-zod" window="__USER__">
+</schema>
+
+<template>
+  <div>{{name}}</div>
+</template>

--- a/spec/fixtures/templates/schema_test/invalid_src_path.rue
+++ b/spec/fixtures/templates/schema_test/invalid_src_path.rue
@@ -1,0 +1,6 @@
+<schema src="nonexistent/schema.ts" lang="js-zod" window="__DATA__">
+</schema>
+
+<template>
+  <div>Test</div>
+</template>

--- a/spec/fixtures/templates/schema_test/path_traversal_attempt.rue
+++ b/spec/fixtures/templates/schema_test/path_traversal_attempt.rue
@@ -1,0 +1,6 @@
+<schema src="../../../etc/passwd" lang="js-zod" window="__DATA__">
+</schema>
+
+<template>
+  <div>Test</div>
+</template>

--- a/spec/fixtures/templates/schema_test/schemas/bootstrap.schema.ts
+++ b/spec/fixtures/templates/schema_test/schemas/bootstrap.schema.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+const schema = z.object({
+  appName: z.string(),
+  version: z.string(),
+  features: z.array(z.string()).optional()
+});
+
+export default schema;

--- a/spec/fixtures/templates/schema_test/schemas/user.schema.js
+++ b/spec/fixtures/templates/schema_test/schemas/user.schema.js
@@ -1,0 +1,9 @@
+const { z } = require('zod');
+
+const schema = z.object({
+  id: z.number(),
+  name: z.string(),
+  email: z.string().email()
+});
+
+module.exports = schema;

--- a/spec/rhales/configuration_schema_search_paths_spec.rb
+++ b/spec/rhales/configuration_schema_search_paths_spec.rb
@@ -1,0 +1,75 @@
+# spec/rhales/configuration_schema_search_paths_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rhales::Configuration do
+  describe '#schema_search_paths' do
+    subject { described_class.new }
+
+    describe 'default value' do
+      it 'defaults to an empty array' do
+        expect(subject.schema_search_paths).to eq([])
+      end
+
+      it 'is an array type' do
+        expect(subject.schema_search_paths).to be_an(Array)
+      end
+    end
+
+    describe 'assignment' do
+      it 'accepts an array of paths' do
+        paths = ['/app/schemas', '/lib/shared/schemas']
+        subject.schema_search_paths = paths
+        expect(subject.schema_search_paths).to eq(paths)
+      end
+
+      it 'accepts an empty array' do
+        subject.schema_search_paths = []
+        expect(subject.schema_search_paths).to eq([])
+      end
+
+      it 'accepts a single path in an array' do
+        subject.schema_search_paths = ['/single/path']
+        expect(subject.schema_search_paths).to eq(['/single/path'])
+      end
+    end
+
+    describe 'configuration block' do
+      before { Rhales.reset_configuration! }
+
+      it 'can be configured via Rhales.configure' do
+        Rhales.configure do |config|
+          config.schema_search_paths = ['/custom/schemas', '/shared/schemas']
+        end
+
+        expect(Rhales.config.schema_search_paths).to eq(['/custom/schemas', '/shared/schemas'])
+      end
+
+      it 'preserves paths through freeze' do
+        Rhales.configure do |config|
+          config.schema_search_paths = ['/frozen/path']
+        end
+
+        expect(Rhales.config.schema_search_paths).to eq(['/frozen/path'])
+        expect(Rhales.config).to be_frozen
+      end
+    end
+
+    describe 'validation' do
+      # schema_search_paths validation is minimal - paths are validated at resolution time
+      # This matches the pattern used by template_paths
+
+      it 'does not raise on non-existent paths (validation is deferred)' do
+        subject.schema_search_paths = ['/nonexistent/path']
+        expect { subject.validate! }.not_to raise_error
+      end
+
+      it 'accepts relative paths' do
+        subject.schema_search_paths = ['./schemas', '../shared/schemas']
+        expect(subject.schema_search_paths).to eq(['./schemas', '../shared/schemas'])
+      end
+    end
+  end
+end

--- a/spec/rhales/configuration_schema_search_paths_spec.rb
+++ b/spec/rhales/configuration_schema_search_paths_spec.rb
@@ -3,6 +3,8 @@
 # frozen_string_literal: true
 
 require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
 
 RSpec.describe Rhales::Configuration do
   describe '#schema_search_paths' do
@@ -37,38 +39,62 @@ RSpec.describe Rhales::Configuration do
     end
 
     describe 'configuration block' do
-      before { Rhales.reset_configuration! }
+      let(:temp_dirs) { [] }
+
+      before do
+        Rhales.reset_configuration!
+      end
+
+      after do
+        temp_dirs.each { |d| FileUtils.rm_rf(d) if Dir.exist?(d) }
+      end
 
       it 'can be configured via Rhales.configure' do
+        dir1 = Dir.mktmpdir('custom_schemas')
+        dir2 = Dir.mktmpdir('shared_schemas')
+        temp_dirs.push(dir1, dir2)
+
         Rhales.configure do |config|
-          config.schema_search_paths = ['/custom/schemas', '/shared/schemas']
+          config.schema_search_paths = [dir1, dir2]
         end
 
-        expect(Rhales.config.schema_search_paths).to eq(['/custom/schemas', '/shared/schemas'])
+        expect(Rhales.config.schema_search_paths).to eq([dir1, dir2])
       end
 
       it 'preserves paths through freeze' do
+        dir = Dir.mktmpdir('frozen_path')
+        temp_dirs.push(dir)
+
         Rhales.configure do |config|
-          config.schema_search_paths = ['/frozen/path']
+          config.schema_search_paths = [dir]
         end
 
-        expect(Rhales.config.schema_search_paths).to eq(['/frozen/path'])
+        expect(Rhales.config.schema_search_paths).to eq([dir])
         expect(Rhales.config).to be_frozen
       end
     end
 
     describe 'validation' do
-      # schema_search_paths validation is minimal - paths are validated at resolution time
-      # This matches the pattern used by template_paths
-
-      it 'does not raise on non-existent paths (validation is deferred)' do
+      it 'raises on non-existent paths during validate!' do
         subject.schema_search_paths = ['/nonexistent/path']
+        expect { subject.validate! }.to raise_error(
+          Rhales::Configuration::ConfigurationError,
+          /Schema search path does not exist/
+        )
+      end
+
+      it 'accepts relative paths that exist' do
+        # Use current directory which always exists
+        subject.schema_search_paths = ['.']
         expect { subject.validate! }.not_to raise_error
       end
 
-      it 'accepts relative paths' do
-        subject.schema_search_paths = ['./schemas', '../shared/schemas']
-        expect(subject.schema_search_paths).to eq(['./schemas', '../shared/schemas'])
+      it 'validates all paths and reports all errors' do
+        subject.schema_search_paths = ['/nonexistent/path1', '/nonexistent/path2']
+        expect { subject.validate! }.to raise_error(
+          Rhales::Configuration::ConfigurationError,
+          /path1.*path2|path2.*path1/
+        )
       end
     end
   end

--- a/spec/rhales/configuration_spec.rb
+++ b/spec/rhales/configuration_spec.rb
@@ -193,6 +193,45 @@ RSpec.describe Rhales::Configuration do
       expect(subject.hydration_authority).to eq(:data)
     end
   end
+
+  describe '#schema_search_paths' do
+    subject { described_class.new }
+
+    it 'defaults to empty array' do
+      expect(subject.schema_search_paths).to eq([])
+    end
+
+    it 'allows setting schema_search_paths to an array of paths' do
+      subject.schema_search_paths = ['./apps/web/core/templates', './src/schemas']
+      expect(subject.schema_search_paths).to eq(['./apps/web/core/templates', './src/schemas'])
+    end
+  end
+
+  describe '#schema_tsconfig_path' do
+    subject { described_class.new }
+
+    it 'defaults to nil' do
+      expect(subject.schema_tsconfig_path).to be_nil
+    end
+
+    it 'allows setting schema_tsconfig_path' do
+      subject.schema_tsconfig_path = './tsconfig.json'
+      expect(subject.schema_tsconfig_path).to eq('./tsconfig.json')
+    end
+  end
+
+  describe '#schema_use_tsx_import' do
+    subject { described_class.new }
+
+    it 'defaults to false' do
+      expect(subject.schema_use_tsx_import).to be(false)
+    end
+
+    it 'allows enabling schema_use_tsx_import' do
+      subject.schema_use_tsx_import = true
+      expect(subject.schema_use_tsx_import).to be(true)
+    end
+  end
 end
 
 RSpec.describe Rhales do

--- a/spec/rhales/core/rue_document_src_attribute_spec.rb
+++ b/spec/rhales/core/rue_document_src_attribute_spec.rb
@@ -1,0 +1,85 @@
+# spec/rhales/core/rue_document_src_attribute_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Rhales::RueDocument do
+  describe 'src attribute support' do
+    context 'KNOWN_SCHEMA_ATTRIBUTES' do
+      it 'includes src in the known attributes list' do
+        expect(described_class::KNOWN_SCHEMA_ATTRIBUTES).to include('src')
+      end
+    end
+
+    context '#schema_src accessor' do
+      let(:rue_content_with_src) do
+        <<~RUE
+          <schema src="schemas/bootstrap.schema.ts" lang="js-zod" window="__DATA__">
+          </schema>
+
+          <template>
+          <div>Test</div>
+          </template>
+        RUE
+      end
+
+      let(:rue_content_without_src) do
+        <<~RUE
+          <schema lang="js-zod" window="__DATA__">
+          const schema = z.object({ name: z.string() });
+          </schema>
+
+          <template>
+          <div>Test</div>
+          </template>
+        RUE
+      end
+
+      it 'returns the src attribute value when present' do
+        doc = described_class.new(rue_content_with_src)
+        doc.parse!
+        expect(doc.schema_src).to eq('schemas/bootstrap.schema.ts')
+      end
+
+      it 'returns nil when src attribute is not present' do
+        doc = described_class.new(rue_content_without_src)
+        doc.parse!
+        expect(doc.schema_src).to be_nil
+      end
+    end
+
+    context 'attribute validation' do
+      let(:rue_content_with_unknown_attr) do
+        <<~RUE
+          <schema unknown_attr="value" lang="js-zod" window="__DATA__">
+          const schema = z.object({});
+          </schema>
+
+          <template>
+          <div>Test</div>
+          </template>
+        RUE
+      end
+
+      it 'does not warn about src attribute' do
+        rue_content = <<~RUE
+          <schema src="schemas/test.ts" lang="js-zod" window="__DATA__">
+          </schema>
+
+          <template>
+          <div>Test</div>
+          </template>
+        RUE
+
+        doc = described_class.new(rue_content)
+        expect { doc.parse! }.not_to output(/unknown schema attribute.*src/i).to_stderr
+      end
+
+      it 'still warns about truly unknown attributes' do
+        doc = described_class.new(rue_content_with_unknown_attr)
+        expect { doc.parse! }.to output(/unknown_attr.*attribute.*not yet supported/i).to_stderr
+      end
+    end
+  end
+end

--- a/spec/rhales/integration/external_schema_spec.rb
+++ b/spec/rhales/integration/external_schema_spec.rb
@@ -1,0 +1,206 @@
+# spec/rhales/integration/external_schema_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
+require 'json'
+
+RSpec.describe 'External schema integration' do
+  let(:temp_dir) { Dir.mktmpdir('rhales_external_schema_integration') }
+  let(:templates_dir) { File.join(temp_dir, 'templates') }
+  let(:schemas_dir) { File.join(templates_dir, 'schemas') }
+  let(:output_dir) { File.join(temp_dir, 'output') }
+
+  before do
+    FileUtils.mkdir_p(schemas_dir)
+    FileUtils.mkdir_p(output_dir)
+  end
+
+  after do
+    FileUtils.remove_entry(temp_dir) if File.exist?(temp_dir)
+  end
+
+  def create_file(path, content)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+  end
+
+  describe 'end-to-end workflow' do
+    let(:external_schema_ts) do
+      <<~TS
+        import { z } from 'zod';
+
+        const schema = z.object({
+          userId: z.number(),
+          username: z.string(),
+          email: z.string().email(),
+          roles: z.array(z.string()).optional()
+        });
+
+        export default schema;
+      TS
+    end
+
+    let(:template_with_external_src) do
+      <<~RUE
+        <schema src="schemas/user.schema.ts" lang="js-zod" window="__USER_DATA__">
+        </schema>
+
+        <template>
+        <div class="user-profile">
+          <h1>{{username}}</h1>
+          <p>{{email}}</p>
+        </div>
+        </template>
+      RUE
+    end
+
+    before do
+      create_file(File.join(schemas_dir, 'user.schema.ts'), external_schema_ts)
+      create_file(File.join(templates_dir, 'user_profile.rue'), template_with_external_src)
+    end
+
+    it 'parses template with external schema reference' do
+      doc = Rhales::RueDocument.parse_file(File.join(templates_dir, 'user_profile.rue'))
+
+      expect(doc.schema_src).to eq('schemas/user.schema.ts')
+      expect(doc.schema_lang).to eq('js-zod')
+      expect(doc.schema_window).to eq('__USER_DATA__')
+    end
+
+    it 'extracts schema from external file' do
+      extractor = Rhales::SchemaExtractor.new(templates_dir)
+      schemas = extractor.extract_all
+
+      expect(schemas.length).to eq(1)
+      schema_info = schemas.first
+
+      expect(schema_info[:template_name]).to eq('user_profile')
+      expect(schema_info[:src]).to eq('schemas/user.schema.ts')
+      expect(schema_info[:resolved_path]).to eq(File.join(schemas_dir, 'user.schema.ts'))
+      expect(schema_info[:schema_code]).to include('z.object')
+      expect(schema_info[:schema_code]).to include('userId')
+      expect(schema_info[:schema_code]).to include('z.string().email()')
+    end
+
+    context 'with mocked TypeScript execution' do
+      let(:mock_json_schema) do
+        {
+          '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+          'type' => 'object',
+          'properties' => {
+            'userId' => { 'type' => 'number' },
+            'username' => { 'type' => 'string' },
+            'email' => { 'type' => 'string', 'format' => 'email' },
+            'roles' => {
+              'type' => 'array',
+              'items' => { 'type' => 'string' }
+            }
+          },
+          'required' => %w[userId username email]
+        }
+      end
+
+      before do
+        # Mock validation checks
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', '--version')
+          .and_return(['8.0.0', '', double(success?: true)])
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', 'exec', 'tsx', '--version')
+          .and_return(['4.0.0', '', double(success?: true)])
+        # Mock actual TypeScript execution
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', 'exec', 'tsx', anything)
+          .and_return([JSON.generate(mock_json_schema), '', double(success?: true)])
+      end
+
+      it 'generates JSON Schema from external Zod schema' do
+        extractor = Rhales::SchemaExtractor.new(templates_dir)
+        schemas = extractor.extract_all
+
+        generator = Rhales::SchemaGenerator.new(templates_dir: templates_dir, output_dir: output_dir)
+        result = generator.generate_schema(schemas.first)
+
+        expect(result['type']).to eq('object')
+        expect(result['properties']['userId']['type']).to eq('number')
+        expect(result['properties']['email']['format']).to eq('email')
+      end
+    end
+  end
+
+  describe 'mixed inline and external schemas' do
+    let(:external_schema) { "const schema = z.object({ ext: z.boolean() });" }
+    let(:inline_schema) { "const schema = z.object({ inline: z.string() });" }
+
+    before do
+      create_file(File.join(schemas_dir, 'external.ts'), external_schema)
+
+      create_file(File.join(templates_dir, 'external_ref.rue'), <<~RUE)
+        <schema src="schemas/external.ts" lang="js-zod" window="__EXT__">
+        </schema>
+        <template><div>External</div></template>
+      RUE
+
+      create_file(File.join(templates_dir, 'inline_def.rue'), <<~RUE)
+        <schema lang="js-zod" window="__INLINE__">
+        #{inline_schema}
+        </schema>
+        <template><div>Inline</div></template>
+      RUE
+    end
+
+    it 'handles both types in the same templates directory' do
+      extractor = Rhales::SchemaExtractor.new(templates_dir)
+      schemas = extractor.extract_all
+
+      external = schemas.find { |s| s[:template_name] == 'external_ref' }
+      inline = schemas.find { |s| s[:template_name] == 'inline_def' }
+
+      expect(external[:src]).to eq('schemas/external.ts')
+      expect(external[:schema_code]).to include('ext: z.boolean()')
+
+      expect(inline[:src]).to be_nil
+      expect(inline[:schema_code]).to include('inline: z.string()')
+    end
+  end
+
+  describe 'schema stats reporting' do
+    before do
+      create_file(File.join(schemas_dir, 'shared.ts'), "const schema = z.object({});")
+
+      3.times do |i|
+        create_file(File.join(templates_dir, "external_#{i}.rue"), <<~RUE)
+          <schema src="schemas/shared.ts" lang="js-zod" window="__DATA__">
+          </schema>
+          <template><div>External #{i}</div></template>
+        RUE
+      end
+
+      2.times do |i|
+        create_file(File.join(templates_dir, "inline_#{i}.rue"), <<~RUE)
+          <schema lang="js-zod" window="__DATA__">
+          const schema = z.object({ i: z.literal(#{i}) });
+          </schema>
+          <template><div>Inline #{i}</div></template>
+        RUE
+      end
+
+      create_file(File.join(templates_dir, 'no_schema.rue'), <<~RUE)
+        <template><div>No schema</div></template>
+      RUE
+    end
+
+    it 'reports accurate counts for external vs inline' do
+      extractor = Rhales::SchemaExtractor.new(templates_dir)
+      stats = extractor.schema_stats
+
+      expect(stats[:total_files]).to eq(6)
+      expect(stats[:files_with_schemas]).to eq(5)
+      expect(stats[:external_schemas]).to eq(3)
+      expect(stats[:inline_schemas]).to eq(2)
+    end
+  end
+end

--- a/spec/rhales/tasks/schema_tasks_spec.rb
+++ b/spec/rhales/tasks/schema_tasks_spec.rb
@@ -115,7 +115,7 @@ RSpec.describe 'rhales:schema rake tasks' do
 
         expect(output).to include('Schema Generation')
         expect(output).to include('Found 1 schema section(s)')
-        expect(output).to include('test_template (js-zod)')
+        expect(output).to include('test_template (js-zod, inline)')
         expect(output).to include('Successfully generated 1 schema(s)')
 
         # Verify output file exists

--- a/spec/rhales/utils/schema_extractor_search_paths_spec.rb
+++ b/spec/rhales/utils/schema_extractor_search_paths_spec.rb
@@ -1,0 +1,216 @@
+# spec/rhales/utils/schema_extractor_search_paths_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
+
+RSpec.describe Rhales::SchemaExtractor do
+  describe 'schema_search_paths configuration support' do
+    let(:temp_dir) { Dir.mktmpdir('rhales_search_paths_test') }
+    let(:templates_dir) { File.join(temp_dir, 'templates') }
+    let(:shared_schemas_dir) { File.join(temp_dir, 'shared_schemas') }
+    let(:lib_schemas_dir) { File.join(temp_dir, 'lib', 'schemas') }
+
+    before do
+      FileUtils.mkdir_p(templates_dir)
+      FileUtils.mkdir_p(shared_schemas_dir)
+      FileUtils.mkdir_p(lib_schemas_dir)
+    end
+
+    after do
+      FileUtils.remove_entry(temp_dir) if File.exist?(temp_dir)
+    end
+
+    def create_file(path, content)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, content)
+    end
+
+    let(:common_schema_content) do
+      <<~TS
+        import { z } from 'zod';
+        const schema = z.object({ common: z.string() });
+        export default schema;
+      TS
+    end
+
+    describe 'current behavior (relative to template)' do
+      # Document the current behavior before search paths are implemented
+
+      it 'resolves src paths relative to template directory' do
+        create_file(File.join(templates_dir, 'schemas', 'local.ts'), common_schema_content)
+        create_file(File.join(templates_dir, 'page.rue'), <<~RUE)
+          <schema src="schemas/local.ts" lang="js-zod" window="__DATA__">
+          </schema>
+          <template><div>Test</div></template>
+        RUE
+
+        extractor = described_class.new(templates_dir)
+        result = extractor.extract_from_file(File.join(templates_dir, 'page.rue'))
+
+        expect(result[:resolved_path]).to eq(File.join(templates_dir, 'schemas', 'local.ts'))
+        expect(result[:schema_code]).to include('common: z.string()')
+      end
+
+      it 'raises error when schema file not found in relative path' do
+        create_file(File.join(templates_dir, 'missing_ref.rue'), <<~RUE)
+          <schema src="schemas/nonexistent.ts" lang="js-zod" window="__DATA__">
+          </schema>
+          <template><div>Test</div></template>
+        RUE
+
+        extractor = described_class.new(templates_dir)
+
+        expect {
+          extractor.extract_from_file(File.join(templates_dir, 'missing_ref.rue'))
+        }.to raise_error(Rhales::SchemaExtractor::ExtractionError, /not found/i)
+      end
+    end
+
+    # Tests for search paths resolution feature
+    describe 'search paths resolution' do
+      before do
+        # Configure search paths via Rhales configuration
+        Rhales.reset_configuration!
+        Rhales.configure do |config|
+          config.schema_search_paths = [shared_schemas_dir, lib_schemas_dir]
+          config.template_paths = [templates_dir]
+        end
+      end
+
+      context 'when src is found in search paths' do
+        before do
+          create_file(File.join(shared_schemas_dir, 'common.ts'), common_schema_content)
+          create_file(File.join(templates_dir, 'uses_shared.rue'), <<~RUE)
+            <schema src="common.ts" lang="js-zod" window="__DATA__">
+            </schema>
+            <template><div>Test</div></template>
+          RUE
+        end
+
+        it 'resolves schema from search paths when not found relative to template' do
+          extractor = described_class.new(templates_dir)
+          result = extractor.extract_from_file(File.join(templates_dir, 'uses_shared.rue'))
+
+          expect(result[:resolved_path]).to eq(File.join(shared_schemas_dir, 'common.ts'))
+        end
+
+        it 'searches paths in order (first match wins)' do
+          # Create same file in both search paths
+          create_file(File.join(shared_schemas_dir, 'duplicate.ts'), "const schema = z.object({ from: z.literal('shared') });")
+          create_file(File.join(lib_schemas_dir, 'duplicate.ts'), "const schema = z.object({ from: z.literal('lib') });")
+
+          create_file(File.join(templates_dir, 'uses_duplicate.rue'), <<~RUE)
+            <schema src="duplicate.ts" lang="js-zod" window="__DATA__">
+            </schema>
+            <template><div>Test</div></template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+          result = extractor.extract_from_file(File.join(templates_dir, 'uses_duplicate.rue'))
+
+          # First path in search_paths should win
+          expect(result[:resolved_path]).to eq(File.join(shared_schemas_dir, 'duplicate.ts'))
+          expect(result[:schema_code]).to include("'shared'")
+        end
+      end
+
+      context 'when src is not found in any search path' do
+        it 'raises error with all searched locations' do
+          create_file(File.join(templates_dir, 'not_found.rue'), <<~RUE)
+            <schema src="missing.ts" lang="js-zod" window="__DATA__">
+            </schema>
+            <template><div>Test</div></template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+
+          expect {
+            extractor.extract_from_file(File.join(templates_dir, 'not_found.rue'))
+          }.to raise_error(Rhales::SchemaExtractor::ExtractionError, /not found/i)
+        end
+      end
+
+      context 'priority: template-relative over search paths' do
+        it 'prefers template-relative path when file exists in both locations' do
+          # Create in both template dir and search path
+          create_file(File.join(templates_dir, 'local_priority.ts'), "const schema = z.object({ from: z.literal('template') });")
+          create_file(File.join(shared_schemas_dir, 'local_priority.ts'), "const schema = z.object({ from: z.literal('shared') });")
+
+          create_file(File.join(templates_dir, 'priority_test.rue'), <<~RUE)
+            <schema src="local_priority.ts" lang="js-zod" window="__DATA__">
+            </schema>
+            <template><div>Test</div></template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+          result = extractor.extract_from_file(File.join(templates_dir, 'priority_test.rue'))
+
+          # Template-relative should win
+          expect(result[:resolved_path]).to eq(File.join(templates_dir, 'local_priority.ts'))
+          expect(result[:schema_code]).to include("'template'")
+        end
+      end
+
+      context 'security with search paths' do
+        it 'prevents path traversal in search path resolution' do
+          create_file(File.join(templates_dir, 'traversal_via_search.rue'), <<~RUE)
+            <schema src="../../../etc/passwd" lang="js-zod" window="__DATA__">
+            </schema>
+            <template><div>Test</div></template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+
+          expect {
+            extractor.extract_from_file(File.join(templates_dir, 'traversal_via_search.rue'))
+          }.to raise_error(Rhales::SchemaExtractor::ExtractionError, /path traversal|not allowed/i)
+        end
+
+        it 'only searches within configured search paths' do
+          # Schema exists outside search paths
+          outside_path = File.join(temp_dir, 'outside', 'secret.ts')
+          create_file(outside_path, 'secret content')
+
+          create_file(File.join(templates_dir, 'outside_search.rue'), <<~RUE)
+            <schema src="../outside/secret.ts" lang="js-zod" window="__DATA__">
+            </schema>
+            <template><div>Test</div></template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+
+          expect {
+            extractor.extract_from_file(File.join(templates_dir, 'outside_search.rue'))
+          }.to raise_error(Rhales::SchemaExtractor::ExtractionError)
+        end
+      end
+    end
+
+    describe 'empty search paths' do
+      before do
+        Rhales.reset_configuration!
+        Rhales.configure do |config|
+          config.schema_search_paths = []
+          config.template_paths = [templates_dir]
+        end
+      end
+
+      it 'falls back to template-relative resolution with empty search paths' do
+        create_file(File.join(templates_dir, 'schemas', 'fallback.ts'), common_schema_content)
+        create_file(File.join(templates_dir, 'fallback_test.rue'), <<~RUE)
+          <schema src="schemas/fallback.ts" lang="js-zod" window="__DATA__">
+          </schema>
+          <template><div>Test</div></template>
+        RUE
+
+        extractor = described_class.new(templates_dir)
+        result = extractor.extract_from_file(File.join(templates_dir, 'fallback_test.rue'))
+
+        expect(result[:resolved_path]).to eq(File.join(templates_dir, 'schemas', 'fallback.ts'))
+      end
+    end
+  end
+end

--- a/spec/rhales/utils/schema_extractor_search_paths_spec.rb
+++ b/spec/rhales/utils/schema_extractor_search_paths_spec.rb
@@ -129,7 +129,14 @@ RSpec.describe Rhales::SchemaExtractor do
 
           expect {
             extractor.extract_from_file(File.join(templates_dir, 'not_found.rue'))
-          }.to raise_error(Rhales::SchemaExtractor::ExtractionError, /not found/i)
+          }.to raise_error(Rhales::SchemaExtractor::ExtractionError) do |error|
+            expect(error.message).to include('not found')
+            expect(error.message).to include('Searched:')
+            # Verify all search locations are listed
+            expect(error.message).to include(templates_dir)
+            expect(error.message).to include(shared_schemas_dir)
+            expect(error.message).to include(lib_schemas_dir)
+          end
         end
       end
 

--- a/spec/rhales/utils/schema_extractor_src_spec.rb
+++ b/spec/rhales/utils/schema_extractor_src_spec.rb
@@ -1,0 +1,312 @@
+# spec/rhales/utils/schema_extractor_src_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+require 'tmpdir'
+
+RSpec.describe Rhales::SchemaExtractor do
+  describe 'external schema src attribute support' do
+    let(:temp_dir) { Dir.mktmpdir('rhales_schema_src_test') }
+    let(:templates_dir) { File.join(temp_dir, 'templates') }
+    let(:schemas_dir) { File.join(templates_dir, 'schemas') }
+
+    before do
+      FileUtils.mkdir_p(schemas_dir)
+    end
+
+    after do
+      FileUtils.remove_entry(temp_dir) if File.exist?(temp_dir)
+    end
+
+    def create_file(path, content)
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, content)
+    end
+
+    describe '#extract_from_file with src attribute' do
+      let(:external_schema_content) do
+        <<~TS
+          import { z } from 'zod';
+
+          const schema = z.object({
+            appName: z.string(),
+            version: z.string()
+          });
+
+          export default schema;
+        TS
+      end
+
+      context 'path resolution' do
+        it 'resolves src path relative to template directory' do
+          create_file(File.join(schemas_dir, 'bootstrap.schema.ts'), external_schema_content)
+          create_file(File.join(templates_dir, 'dashboard.rue'), <<~RUE)
+            <schema src="schemas/bootstrap.schema.ts" lang="js-zod" window="__DATA__">
+            </schema>
+
+            <template>
+            <div>Test</div>
+            </template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+          result = extractor.extract_from_file(File.join(templates_dir, 'dashboard.rue'))
+
+          expect(result[:src]).to eq('schemas/bootstrap.schema.ts')
+          expect(result[:resolved_path]).to eq(File.join(schemas_dir, 'bootstrap.schema.ts'))
+          expect(result[:schema_code]).to include("z.object")
+        end
+
+        it 'resolves relative paths with ./ prefix' do
+          create_file(File.join(schemas_dir, 'user.schema.ts'), external_schema_content)
+          create_file(File.join(templates_dir, 'user.rue'), <<~RUE)
+            <schema src="./schemas/user.schema.ts" lang="js-zod" window="__USER__">
+            </schema>
+
+            <template>
+            <div>Test</div>
+            </template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+          result = extractor.extract_from_file(File.join(templates_dir, 'user.rue'))
+
+          expect(result[:resolved_path]).to eq(File.join(schemas_dir, 'user.schema.ts'))
+        end
+
+        it 'resolves paths for nested templates' do
+          nested_dir = File.join(templates_dir, 'pages', 'admin')
+          nested_schemas = File.join(nested_dir, 'schemas')
+          FileUtils.mkdir_p(nested_schemas)
+
+          create_file(File.join(nested_schemas, 'admin.schema.ts'), external_schema_content)
+          create_file(File.join(nested_dir, 'dashboard.rue'), <<~RUE)
+            <schema src="schemas/admin.schema.ts" lang="js-zod" window="__ADMIN__">
+            </schema>
+
+            <template>
+            <div>Test</div>
+            </template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+          result = extractor.extract_from_file(File.join(nested_dir, 'dashboard.rue'))
+
+          expect(result[:resolved_path]).to eq(File.join(nested_schemas, 'admin.schema.ts'))
+        end
+      end
+
+      context 'inline schemas (no src)' do
+        it 'continues to work with inline schemas' do
+          create_file(File.join(templates_dir, 'inline.rue'), <<~RUE)
+            <schema lang="js-zod" window="__DATA__">
+            const schema = z.object({ name: z.string() });
+            </schema>
+
+            <template>
+            <div>Test</div>
+            </template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+          result = extractor.extract_from_file(File.join(templates_dir, 'inline.rue'))
+
+          expect(result[:src]).to be_nil
+          expect(result[:resolved_path]).to be_nil
+          expect(result[:schema_code]).to include("z.object")
+        end
+      end
+
+      context 'error handling' do
+        it 'raises error when src file does not exist' do
+          create_file(File.join(templates_dir, 'missing_src.rue'), <<~RUE)
+            <schema src="nonexistent/schema.ts" lang="js-zod" window="__DATA__">
+            </schema>
+
+            <template>
+            <div>Test</div>
+            </template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+
+          expect {
+            extractor.extract_from_file(File.join(templates_dir, 'missing_src.rue'))
+          }.to raise_error(Rhales::SchemaExtractor::ExtractionError, /not found|does not exist/i)
+        end
+
+        it 'includes template name and src path in error message' do
+          create_file(File.join(templates_dir, 'bad_ref.rue'), <<~RUE)
+            <schema src="missing/file.ts" lang="js-zod" window="__DATA__">
+            </schema>
+
+            <template>
+            <div>Test</div>
+            </template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+
+          expect {
+            extractor.extract_from_file(File.join(templates_dir, 'bad_ref.rue'))
+          }.to raise_error(Rhales::SchemaExtractor::ExtractionError) { |e|
+            expect(e.message).to include('missing/file.ts')
+          }
+        end
+      end
+
+      context 'security - path traversal prevention' do
+        it 'blocks path traversal attempts outside templates directory' do
+          # Create a file outside templates that attacker might try to access
+          outside_file = File.join(temp_dir, 'secret.txt')
+          create_file(outside_file, 'SECRET DATA')
+
+          create_file(File.join(templates_dir, 'malicious.rue'), <<~RUE)
+            <schema src="../secret.txt" lang="js-zod" window="__DATA__">
+            </schema>
+
+            <template>
+            <div>Test</div>
+            </template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+
+          expect {
+            extractor.extract_from_file(File.join(templates_dir, 'malicious.rue'))
+          }.to raise_error(Rhales::SchemaExtractor::ExtractionError, /path traversal|outside.*directory|not allowed/i)
+        end
+
+        it 'blocks deep path traversal attempts' do
+          create_file(File.join(templates_dir, 'deep_traversal.rue'), <<~RUE)
+            <schema src="../../../etc/passwd" lang="js-zod" window="__DATA__">
+            </schema>
+
+            <template>
+            <div>Test</div>
+            </template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+
+          expect {
+            extractor.extract_from_file(File.join(templates_dir, 'deep_traversal.rue'))
+          }.to raise_error(Rhales::SchemaExtractor::ExtractionError, /path traversal|outside.*directory|not allowed/i)
+        end
+
+        it 'allows legitimate parent directory references within templates' do
+          # Template in nested dir referencing schema in parent
+          nested_dir = File.join(templates_dir, 'pages')
+          FileUtils.mkdir_p(nested_dir)
+
+          create_file(File.join(templates_dir, 'shared', 'common.schema.ts'), external_schema_content)
+          create_file(File.join(nested_dir, 'page.rue'), <<~RUE)
+            <schema src="../shared/common.schema.ts" lang="js-zod" window="__DATA__">
+            </schema>
+
+            <template>
+            <div>Test</div>
+            </template>
+          RUE
+
+          extractor = described_class.new(templates_dir)
+          result = extractor.extract_from_file(File.join(nested_dir, 'page.rue'))
+
+          # Should work because final path is still within templates_dir
+          expect(result[:resolved_path]).to eq(File.join(templates_dir, 'shared', 'common.schema.ts'))
+        end
+      end
+    end
+
+    describe '#extract_all with mixed schemas' do
+      let(:external_schema_content) do
+        "const schema = z.object({ name: z.string() });"
+      end
+
+      before do
+        create_file(File.join(schemas_dir, 'external.schema.ts'), external_schema_content)
+
+        create_file(File.join(templates_dir, 'with_src.rue'), <<~RUE)
+          <schema src="schemas/external.schema.ts" lang="js-zod" window="__DATA__">
+          </schema>
+
+          <template>
+          <div>Test</div>
+          </template>
+        RUE
+
+        create_file(File.join(templates_dir, 'inline_schema.rue'), <<~RUE)
+          <schema lang="js-zod" window="__INLINE__">
+          const schema = z.object({ id: z.number() });
+          </schema>
+
+          <template>
+          <div>Test</div>
+          </template>
+        RUE
+
+        create_file(File.join(templates_dir, 'no_schema.rue'), <<~RUE)
+          <template>
+          <div>No schema here</div>
+          </template>
+        RUE
+      end
+
+      it 'extracts both external and inline schemas' do
+        extractor = described_class.new(templates_dir)
+        results = extractor.extract_all
+
+        expect(results.length).to eq(2)
+
+        external = results.find { |r| r[:template_name] == 'with_src' }
+        inline = results.find { |r| r[:template_name] == 'inline_schema' }
+
+        expect(external[:src]).to eq('schemas/external.schema.ts')
+        expect(external[:resolved_path]).not_to be_nil
+
+        expect(inline[:src]).to be_nil
+        expect(inline[:resolved_path]).to be_nil
+      end
+    end
+
+    describe '#schema_stats with src tracking' do
+      let(:external_schema_content) do
+        "const schema = z.object({ name: z.string() });"
+      end
+
+      before do
+        create_file(File.join(schemas_dir, 'ext.schema.ts'), external_schema_content)
+
+        create_file(File.join(templates_dir, 'ext1.rue'), <<~RUE)
+          <schema src="schemas/ext.schema.ts" lang="js-zod" window="__DATA__">
+          </schema>
+          <template><div>Test</div></template>
+        RUE
+
+        create_file(File.join(templates_dir, 'ext2.rue'), <<~RUE)
+          <schema src="schemas/ext.schema.ts" lang="js-zod" window="__DATA__">
+          </schema>
+          <template><div>Test</div></template>
+        RUE
+
+        create_file(File.join(templates_dir, 'inline1.rue'), <<~RUE)
+          <schema lang="js-zod" window="__DATA__">
+          const schema = z.object({});
+          </schema>
+          <template><div>Test</div></template>
+        RUE
+      end
+
+      it 'reports external vs inline schema counts' do
+        extractor = described_class.new(templates_dir)
+        stats = extractor.schema_stats
+
+        expect(stats[:files_with_schemas]).to eq(3)
+        expect(stats[:external_schemas]).to eq(2)
+        expect(stats[:inline_schemas]).to eq(1)
+      end
+    end
+  end
+end

--- a/spec/rhales/utils/schema_extractor_src_spec.rb
+++ b/spec/rhales/utils/schema_extractor_src_spec.rb
@@ -308,5 +308,128 @@ RSpec.describe Rhales::SchemaExtractor do
         expect(stats[:inline_schemas]).to eq(1)
       end
     end
+
+    describe 'schema_search_paths configuration' do
+      let(:external_schema_content) do
+        "const schema = z.object({ name: z.string() });"
+      end
+
+      # Separate directory outside of templates for shared schemas
+      let(:shared_schemas_dir) { File.join(temp_dir, 'shared_schemas') }
+
+      before do
+        FileUtils.mkdir_p(shared_schemas_dir)
+        Rhales.reset_configuration!
+      end
+
+      after do
+        Rhales.reset_configuration!
+      end
+
+      it 'finds schema in configured search paths when not in template directory' do
+        # Create schema file in shared_schemas_dir (not in templates)
+        create_file(File.join(shared_schemas_dir, 'common.schema.ts'), external_schema_content)
+
+        # Template references schema that only exists in shared_schemas_dir
+        create_file(File.join(templates_dir, 'using_shared.rue'), <<~RUE)
+          <schema src="common.schema.ts" lang="js-zod" window="__DATA__">
+          </schema>
+
+          <template>
+          <div>Test</div>
+          </template>
+        RUE
+
+        # Configure search paths
+        Rhales.configure do |config|
+          config.schema_search_paths = [shared_schemas_dir]
+        end
+
+        extractor = described_class.new(templates_dir)
+        result = extractor.extract_from_file(File.join(templates_dir, 'using_shared.rue'))
+
+        expect(result[:src]).to eq('common.schema.ts')
+        expect(result[:resolved_path]).to eq(File.join(shared_schemas_dir, 'common.schema.ts'))
+        expect(result[:schema_code]).to include("z.object")
+      end
+
+      it 'prefers template-relative path over search paths' do
+        # Create schema in both locations with different content
+        create_file(File.join(templates_dir, 'schemas', 'priority.schema.ts'), "const schema = z.object({ local: z.boolean() });")
+        create_file(File.join(shared_schemas_dir, 'schemas', 'priority.schema.ts'), "const schema = z.object({ shared: z.boolean() });")
+
+        create_file(File.join(templates_dir, 'priority_test.rue'), <<~RUE)
+          <schema src="schemas/priority.schema.ts" lang="js-zod" window="__DATA__">
+          </schema>
+
+          <template>
+          <div>Test</div>
+          </template>
+        RUE
+
+        Rhales.configure do |config|
+          config.schema_search_paths = [shared_schemas_dir]
+        end
+
+        extractor = described_class.new(templates_dir)
+        result = extractor.extract_from_file(File.join(templates_dir, 'priority_test.rue'))
+
+        # Should use the local template-relative path, not the search path
+        expect(result[:resolved_path]).to eq(File.join(templates_dir, 'schemas', 'priority.schema.ts'))
+        expect(result[:schema_code]).to include("local")
+      end
+
+      it 'searches multiple paths in order' do
+        second_search_dir = File.join(temp_dir, 'second_search')
+        FileUtils.mkdir_p(second_search_dir)
+
+        # Only create in second search dir
+        create_file(File.join(second_search_dir, 'only_in_second.schema.ts'), external_schema_content)
+
+        create_file(File.join(templates_dir, 'multi_search.rue'), <<~RUE)
+          <schema src="only_in_second.schema.ts" lang="js-zod" window="__DATA__">
+          </schema>
+
+          <template>
+          <div>Test</div>
+          </template>
+        RUE
+
+        Rhales.configure do |config|
+          config.schema_search_paths = [shared_schemas_dir, second_search_dir]
+        end
+
+        extractor = described_class.new(templates_dir)
+        result = extractor.extract_from_file(File.join(templates_dir, 'multi_search.rue'))
+
+        expect(result[:resolved_path]).to eq(File.join(second_search_dir, 'only_in_second.schema.ts'))
+      end
+
+      it 'blocks path traversal outside of search paths' do
+        # Configure a search path
+        Rhales.configure do |config|
+          config.schema_search_paths = [shared_schemas_dir]
+        end
+
+        # Try to access file outside both templates_dir and search paths
+        outside_file = File.join(temp_dir, 'secret.txt')
+        create_file(outside_file, 'SECRET DATA')
+
+        create_file(File.join(templates_dir, 'traversal_attack.rue'), <<~RUE)
+          <schema src="../secret.txt" lang="js-zod" window="__DATA__">
+          </schema>
+
+          <template>
+          <div>Test</div>
+          </template>
+        RUE
+
+        extractor = described_class.new(templates_dir)
+
+        expect {
+          extractor.extract_from_file(File.join(templates_dir, 'traversal_attack.rue'))
+        }.to raise_error(Rhales::SchemaExtractor::ExtractionError, /path traversal|outside.*directory|not allowed/i)
+      end
+    end
   end
 end

--- a/spec/rhales/utils/schema_generator_error_handling_spec.rb
+++ b/spec/rhales/utils/schema_generator_error_handling_spec.rb
@@ -1,0 +1,420 @@
+# spec/rhales/utils/schema_generator_error_handling_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'fileutils'
+require 'tmpdir'
+
+RSpec.describe Rhales::SchemaGenerator do
+  describe 'error handling' do
+    let(:temp_dir) { Dir.mktmpdir('rhales_schema_generator_errors') }
+    let(:templates_dir) { File.join(temp_dir, 'templates') }
+    let(:output_dir) { File.join(temp_dir, 'output') }
+
+    before do
+      FileUtils.mkdir_p(templates_dir)
+      FileUtils.mkdir_p(output_dir)
+    end
+
+    after do
+      FileUtils.remove_entry(temp_dir) if File.exist?(temp_dir)
+    end
+
+    let(:valid_schema_info) do
+      {
+        template_name: 'test_template',
+        template_path: File.join(templates_dir, 'test_template.rue'),
+        schema_code: 'const schema = z.object({ name: z.string() });',
+        lang: 'js-zod',
+        version: nil,
+        envelope: nil,
+        window: '__DATA__',
+        merge: nil,
+        layout: nil,
+        extends: nil,
+        src: nil,
+        resolved_path: nil
+      }
+    end
+
+    describe 'tsx execution errors' do
+      context 'when pnpm is not installed' do
+        before do
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', '--version')
+            .and_return(['', 'command not found: pnpm', double(success?: false)])
+        end
+
+        it 'raises GenerationError with helpful message' do
+          expect {
+            described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+          }.to raise_error(
+            Rhales::SchemaGenerator::GenerationError,
+            /pnpm not found/i
+          )
+        end
+
+        it 'includes installation instructions in error message' do
+          expect {
+            described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+          }.to raise_error(
+            Rhales::SchemaGenerator::GenerationError,
+            /npm install -g pnpm/
+          )
+        end
+      end
+
+      context 'when tsx is not installed' do
+        before do
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', '--version')
+            .and_return(['8.0.0', '', double(success?: true)])
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', '--version')
+            .and_return(['', 'Command "tsx" not found', double(success?: false)])
+        end
+
+        it 'raises GenerationError with helpful message' do
+          expect {
+            described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+          }.to raise_error(
+            Rhales::SchemaGenerator::GenerationError,
+            /tsx not found/i
+          )
+        end
+
+        it 'includes installation instructions in error message' do
+          expect {
+            described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+          }.to raise_error(
+            Rhales::SchemaGenerator::GenerationError,
+            /pnpm install tsx/
+          )
+        end
+      end
+
+      context 'when esbuild is not installed (with schema_use_tsx_import enabled)' do
+        before do
+          Rhales.reset_configuration!
+          Rhales.configure do |config|
+            config.schema_use_tsx_import = true
+          end
+
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', '--version')
+            .and_return(['8.0.0', '', double(success?: true)])
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', '--version')
+            .and_return(['4.0.0', '', double(success?: true)])
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'esbuild', '--version')
+            .and_return(['', 'Command "esbuild" not found', double(success?: false)])
+        end
+
+        after do
+          Rhales.reset_configuration!
+        end
+
+        it 'raises GenerationError with helpful message' do
+          expect {
+            described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+          }.to raise_error(
+            Rhales::SchemaGenerator::GenerationError,
+            /esbuild not found/i
+          )
+        end
+
+        it 'includes installation instructions in error message' do
+          expect {
+            described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+          }.to raise_error(
+            Rhales::SchemaGenerator::GenerationError,
+            /pnpm install esbuild/
+          )
+        end
+      end
+
+      context 'when TypeScript code has syntax errors' do
+        let(:generator) do
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', '--version')
+            .and_return(['8.0.0', '', double(success?: true)])
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', '--version')
+            .and_return(['4.0.0', '', double(success?: true)])
+          described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+        end
+
+        it 'raises GenerationError with TypeScript error details' do
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', anything)
+            .and_return([
+              '',
+              "SyntaxError: Unexpected token 'const'\n  at line 5",
+              double(success?: false)
+            ])
+
+          expect {
+            generator.generate_schema(valid_schema_info)
+          }.to raise_error(
+            Rhales::SchemaGenerator::GenerationError,
+            /TypeScript execution failed/i
+          )
+        end
+
+        it 'includes the stderr output in the error' do
+          tsx_error = "TypeError: Cannot read properties of undefined (reading 'object')"
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', anything)
+            .and_return(['', tsx_error, double(success?: false)])
+
+          expect {
+            generator.generate_schema(valid_schema_info)
+          }.to raise_error(
+            Rhales::SchemaGenerator::GenerationError,
+            /Cannot read properties of undefined/
+          )
+        end
+      end
+
+      context 'when Zod schema conversion fails' do
+        let(:generator) do
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', '--version')
+            .and_return(['8.0.0', '', double(success?: true)])
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', '--version')
+            .and_return(['4.0.0', '', double(success?: true)])
+          described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+        end
+
+        it 'raises GenerationError when schema variable is undefined' do
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', anything)
+            .and_return([
+              '',
+              "ReferenceError: schema is not defined",
+              double(success?: false)
+            ])
+
+          expect {
+            generator.generate_schema(valid_schema_info)
+          }.to raise_error(
+            Rhales::SchemaGenerator::GenerationError,
+            /schema is not defined/
+          )
+        end
+
+        it 'raises GenerationError for invalid Zod constructs' do
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', anything)
+            .and_return([
+              '',
+              "Error: z.customType is not a function",
+              double(success?: false)
+            ])
+
+          expect {
+            generator.generate_schema(valid_schema_info)
+          }.to raise_error(
+            Rhales::SchemaGenerator::GenerationError,
+            /z.customType is not a function/
+          )
+        end
+      end
+
+      context 'when output is invalid JSON' do
+        let(:generator) do
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', '--version')
+            .and_return(['8.0.0', '', double(success?: true)])
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', '--version')
+            .and_return(['4.0.0', '', double(success?: true)])
+          described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+        end
+
+        it 'raises error when tsx produces non-JSON output' do
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', anything)
+            .and_return([
+              'This is not valid JSON',
+              '',
+              double(success?: true)
+            ])
+
+          expect {
+            generator.generate_schema(valid_schema_info)
+          }.to raise_error(JSON::ParserError)
+        end
+
+        it 'raises error when tsx produces empty output' do
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', anything)
+            .and_return(['', '', double(success?: true)])
+
+          expect {
+            generator.generate_schema(valid_schema_info)
+          }.to raise_error(JSON::ParserError)
+        end
+      end
+    end
+
+    describe 'directory validation' do
+      context 'when templates directory does not exist' do
+        before do
+          allow(Open3).to receive(:capture3).and_return(['1.0', '', double(success?: true)])
+        end
+
+        it 'raises GenerationError' do
+          expect {
+            described_class.new(
+              templates_dir: '/nonexistent/templates',
+              output_dir: output_dir
+            )
+          }.to raise_error(
+            Rhales::SchemaGenerator::GenerationError,
+            /does not exist/i
+          )
+        end
+      end
+
+      context 'when output directory creation fails' do
+        before do
+          allow(Open3).to receive(:capture3).and_return(['1.0', '', double(success?: true)])
+          allow(FileUtils).to receive(:mkdir_p).and_raise(Errno::EACCES, 'Permission denied')
+        end
+
+        it 'raises error when cannot create output directory' do
+          expect {
+            described_class.new(templates_dir: templates_dir, output_dir: '/root/forbidden/schemas')
+          }.to raise_error(Errno::EACCES)
+        end
+      end
+    end
+
+    describe '#generate_all error handling' do
+      let(:generator) do
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', '--version')
+          .and_return(['8.0.0', '', double(success?: true)])
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', 'exec', 'tsx', '--version')
+          .and_return(['4.0.0', '', double(success?: true)])
+        described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+      end
+
+      before do
+        # Create test .rue file
+        File.write(File.join(templates_dir, 'test.rue'), <<~RUE)
+          <schema lang="js-zod" window="__DATA__">
+          const schema = z.object({ name: z.string() });
+          </schema>
+          <template><div>Test</div></template>
+        RUE
+      end
+
+      context 'when generation fails for some schemas' do
+        it 'continues processing remaining schemas' do
+          # First call fails, second succeeds
+          call_count = 0
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', anything) do
+              call_count += 1
+              if call_count == 1
+                ['', 'Error in first schema', double(success?: false)]
+              else
+                [JSON.generate({ 'type' => 'object' }), '', double(success?: true)]
+              end
+            end
+
+          # Create second template
+          File.write(File.join(templates_dir, 'test2.rue'), <<~RUE)
+            <schema lang="js-zod" window="__DATA__">
+            const schema = z.object({ id: z.number() });
+            </schema>
+            <template><div>Test2</div></template>
+          RUE
+
+          result = generator.generate_all
+
+          expect(result[:failed]).to be >= 1
+          expect(result[:errors]).not_to be_empty
+        end
+
+        it 'returns failure summary with error messages' do
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', anything)
+            .and_return(['', 'Schema generation error', double(success?: false)])
+
+          result = generator.generate_all
+
+          expect(result[:success]).to be false
+          expect(result[:failed]).to eq(1)
+          expect(result[:errors].first).to include('test')
+        end
+      end
+
+      context 'when no schemas are found' do
+        before do
+          FileUtils.rm_rf(File.join(templates_dir, 'test.rue'))
+          File.write(File.join(templates_dir, 'no_schema.rue'), <<~RUE)
+            <template><div>No schema here</div></template>
+          RUE
+        end
+
+        it 'returns success with zero generated' do
+          result = generator.generate_all
+
+          expect(result[:success]).to be true
+          expect(result[:generated]).to eq(0)
+          expect(result[:message]).to include('No schemas found')
+        end
+      end
+    end
+
+    describe 'external schema error handling' do
+      let(:external_schema_info) do
+        {
+          template_name: 'external_test',
+          template_path: File.join(templates_dir, 'external_test.rue'),
+          schema_code: 'const schema = z.object({ ext: z.boolean() });',
+          lang: 'js-zod',
+          version: nil,
+          envelope: nil,
+          window: '__DATA__',
+          merge: nil,
+          layout: nil,
+          extends: nil,
+          src: 'schemas/external.ts',
+          resolved_path: File.join(templates_dir, 'schemas/external.ts')
+        }
+      end
+
+      let(:generator) do
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', '--version')
+          .and_return(['8.0.0', '', double(success?: true)])
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', 'exec', 'tsx', '--version')
+          .and_return(['4.0.0', '', double(success?: true)])
+        described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+      end
+
+      it 'includes external source path in error messages' do
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', 'exec', 'tsx', anything)
+          .and_return(['', 'Import error in external file', double(success?: false)])
+
+        expect {
+          generator.generate_schema(external_schema_info)
+        }.to raise_error(
+          Rhales::SchemaGenerator::GenerationError,
+          /Import error/
+        )
+      end
+    end
+  end
+end

--- a/spec/rhales/utils/schema_generator_src_spec.rb
+++ b/spec/rhales/utils/schema_generator_src_spec.rb
@@ -203,13 +203,14 @@ RSpec.describe Rhales::SchemaGenerator do
       end
 
       describe '#build_typescript_import_script (private method via send)' do
-        let(:bundled_file_pattern) { %r{tmp/bundled_external\.schema_\d+\.mjs$} }
+        let(:bundled_file_pattern) { %r{tmp/bundled_external\.schema_\d+_[a-f0-9]+\.mjs$} }
 
         # Helper to mock esbuild bundling that writes to outfile
         def mock_esbuild_bundle_success
           allow(Open3).to receive(:capture3)
             .with('pnpm', 'exec', 'esbuild', schema_file_path,
                   '--bundle', '--format=esm', '--platform=node',
+                  '--external:zod',
                   satisfy { |arg| arg.to_s.start_with?('--outfile=') }) do |*args|
               outfile_path = args.last.sub('--outfile=', '')
               FileUtils.mkdir_p(File.dirname(outfile_path))
@@ -245,12 +246,13 @@ RSpec.describe Rhales::SchemaGenerator do
           expect(bundled_path).to match(bundled_file_pattern)
         end
 
-        it 'generates script that imports from bundled file' do
+        it 'generates script that imports from bundled file URL' do
           mock_esbuild_bundle_success
 
           script, bundled_path = generator.send(:build_typescript_import_script, external_schema_with_path)
 
-          expect(script).to include("import schema from '#{bundled_path}'")
+          # Script uses file:// URL for cross-platform compatibility
+          expect(script).to include("import schema from 'file://#{bundled_path}'")
           expect(script).to include('// Source: schemas/external.schema.ts (bundled via esbuild)')
         end
 
@@ -266,6 +268,7 @@ RSpec.describe Rhales::SchemaGenerator do
           allow(Open3).to receive(:capture3)
             .with('pnpm', 'exec', 'esbuild', schema_file_path,
                   '--bundle', '--format=esm', '--platform=node',
+                  '--external:zod',
                   satisfy { |arg| arg.to_s.start_with?('--outfile=') })
             .and_return(['', 'Syntax error in schema', double(success?: false)])
 

--- a/spec/rhales/utils/schema_generator_src_spec.rb
+++ b/spec/rhales/utils/schema_generator_src_spec.rb
@@ -61,6 +61,16 @@ RSpec.describe Rhales::SchemaGenerator do
         described_class.new(templates_dir: templates_dir, output_dir: output_dir)
       end
 
+      before do
+        # Mock Open3.capture3 for validation checks
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', '--version')
+          .and_return(['8.0.0', '', double(success?: true)])
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', 'exec', 'tsx', '--version')
+          .and_return(['4.0.0', '', double(success?: true)])
+      end
+
       it 'includes inline source comment for inline schemas' do
         script = generator.send(:build_typescript_script, inline_schema_info)
 

--- a/spec/rhales/utils/schema_generator_src_spec.rb
+++ b/spec/rhales/utils/schema_generator_src_spec.rb
@@ -330,6 +330,33 @@ RSpec.describe Rhales::SchemaGenerator do
           generator.send(:execute_tsx, script_path)
         end
       end
+
+      describe '#path_to_file_url (private method via send)' do
+        it 'converts Unix absolute paths to file:// URLs' do
+          result = generator.send(:path_to_file_url, '/home/user/schemas/test.mjs')
+          expect(result).to eq('file:///home/user/schemas/test.mjs')
+        end
+
+        it 'converts Windows paths with drive letters to file:// URLs' do
+          result = generator.send(:path_to_file_url, 'C:\\Users\\dev\\schemas\\test.mjs')
+          expect(result).to eq('file:///C:/Users/dev/schemas/test.mjs')
+        end
+
+        it 'converts Windows paths with forward slashes to file:// URLs' do
+          result = generator.send(:path_to_file_url, 'C:/Users/dev/schemas/test.mjs')
+          expect(result).to eq('file:///C:/Users/dev/schemas/test.mjs')
+        end
+
+        it 'handles lowercase drive letters' do
+          result = generator.send(:path_to_file_url, 'd:\\Projects\\schemas\\test.mjs')
+          expect(result).to eq('file:///d:/Projects/schemas/test.mjs')
+        end
+
+        it 'handles mixed separators in Windows paths' do
+          result = generator.send(:path_to_file_url, 'D:\\Projects/mixed\\path/test.mjs')
+          expect(result).to eq('file:///D:/Projects/mixed/path/test.mjs')
+        end
+      end
     end
   end
 end

--- a/spec/rhales/utils/schema_generator_src_spec.rb
+++ b/spec/rhales/utils/schema_generator_src_spec.rb
@@ -122,5 +122,201 @@ RSpec.describe Rhales::SchemaGenerator do
         expect(result['type']).to eq('object')
       end
     end
+
+    describe 'tsx import mode' do
+      # Define schema file path as a method so it can be used before lazy let evaluation
+      def schema_file_path
+        File.join(templates_dir, 'schemas', 'external.schema.ts')
+      end
+
+      let(:generator) do
+        described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+      end
+
+      let(:external_schema_with_path) do
+        # Create actual file for resolved_path
+        FileUtils.mkdir_p(File.dirname(schema_file_path))
+        File.write(schema_file_path, "export default z.object({ id: z.number() });")
+
+        {
+          template_name: 'import_mode_test',
+          template_path: File.join(templates_dir, 'import_mode_test.rue'),
+          schema_code: 'const schema = z.object({ id: z.number() });',
+          lang: 'js-zod',
+          version: nil,
+          envelope: nil,
+          window: '__DATA__',
+          merge: nil,
+          layout: nil,
+          extends: nil,
+          src: 'schemas/external.schema.ts',
+          resolved_path: schema_file_path
+        }
+      end
+
+      before do
+        Rhales.reset_configuration!
+
+        # Mock Open3.capture3 for validation checks
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', '--version')
+          .and_return(['8.0.0', '', double(success?: true)])
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', 'exec', 'tsx', '--version')
+          .and_return(['4.0.0', '', double(success?: true)])
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', 'exec', 'esbuild', '--version')
+          .and_return(['0.20.0', '', double(success?: true)])
+      end
+
+      after do
+        Rhales.reset_configuration!
+      end
+
+      describe '#use_tsx_import_mode? (private method via send)' do
+        it 'returns false when schema_use_tsx_import is disabled' do
+          Rhales.configure do |config|
+            config.schema_use_tsx_import = false
+          end
+
+          result = generator.send(:use_tsx_import_mode?, external_schema_with_path)
+          expect(result).to be(false)
+        end
+
+        it 'returns false for inline schemas even when tsx import is enabled' do
+          Rhales.configure do |config|
+            config.schema_use_tsx_import = true
+          end
+
+          result = generator.send(:use_tsx_import_mode?, inline_schema_info)
+          expect(result).to be(false)
+        end
+
+        it 'returns true for external schemas when tsx import is enabled' do
+          Rhales.configure do |config|
+            config.schema_use_tsx_import = true
+          end
+
+          result = generator.send(:use_tsx_import_mode?, external_schema_with_path)
+          expect(result).to be(true)
+        end
+      end
+
+      describe '#build_typescript_import_script (private method via send)' do
+        let(:bundled_file_pattern) { %r{tmp/bundled_external\.schema_\d+\.mjs$} }
+
+        # Helper to mock esbuild bundling that writes to outfile
+        def mock_esbuild_bundle_success
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'esbuild', schema_file_path,
+                  '--bundle', '--format=esm', '--platform=node',
+                  satisfy { |arg| arg.to_s.start_with?('--outfile=') }) do |*args|
+              outfile_path = args.last.sub('--outfile=', '')
+              FileUtils.mkdir_p(File.dirname(outfile_path))
+              File.write(outfile_path, "export default { type: 'object' };")
+              ['', '', double(success?: true)]
+            end
+        end
+
+        before do
+          Rhales.configure do |config|
+            config.schema_use_tsx_import = true
+          end
+
+          # Force file creation before mocking
+          external_schema_with_path
+        end
+
+        after do
+          # Clean up any bundled files
+          Dir.glob(File.join(Dir.pwd, 'tmp', 'bundled_*.mjs')).each { |f| File.unlink(f) rescue nil }
+        end
+
+        it 'returns script and bundled file path' do
+          mock_esbuild_bundle_success
+
+          result = generator.send(:build_typescript_import_script, external_schema_with_path)
+
+          expect(result).to be_an(Array)
+          expect(result.length).to eq(2)
+
+          script, bundled_path = result
+          expect(script).to be_a(String)
+          expect(bundled_path).to match(bundled_file_pattern)
+        end
+
+        it 'generates script that imports from bundled file' do
+          mock_esbuild_bundle_success
+
+          script, bundled_path = generator.send(:build_typescript_import_script, external_schema_with_path)
+
+          expect(script).to include("import schema from '#{bundled_path}'")
+          expect(script).to include('// Source: schemas/external.schema.ts (bundled via esbuild)')
+        end
+
+        it 'creates the bundled file via esbuild' do
+          mock_esbuild_bundle_success
+
+          _script, bundled_path = generator.send(:build_typescript_import_script, external_schema_with_path)
+
+          expect(File.exist?(bundled_path)).to be(true)
+        end
+
+        it 'raises GenerationError when esbuild fails' do
+          allow(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'esbuild', schema_file_path,
+                  '--bundle', '--format=esm', '--platform=node',
+                  satisfy { |arg| arg.to_s.start_with?('--outfile=') })
+            .and_return(['', 'Syntax error in schema', double(success?: false)])
+
+          expect {
+            generator.send(:build_typescript_import_script, external_schema_with_path)
+          }.to raise_error(Rhales::SchemaGenerator::GenerationError, /esbuild bundling failed/)
+        end
+      end
+
+      describe '#execute_tsx (private method via send)' do
+        let(:script_path) { '/tmp/test_script.mts' }
+
+        it 'executes without tsconfig when not configured' do
+          Rhales.configure do |config|
+            config.schema_tsconfig_path = nil
+          end
+
+          expect(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', script_path)
+            .and_return(['{}', '', double(success?: true)])
+
+          generator.send(:execute_tsx, script_path)
+        end
+
+        it 'executes with tsconfig when configured and file exists' do
+          tsconfig_file = File.join(temp_dir, 'tsconfig.json')
+          File.write(tsconfig_file, '{}')
+
+          Rhales.configure do |config|
+            config.schema_tsconfig_path = tsconfig_file
+          end
+
+          expect(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', '--tsconfig', tsconfig_file, script_path)
+            .and_return(['{}', '', double(success?: true)])
+
+          generator.send(:execute_tsx, script_path)
+        end
+
+        it 'falls back to no tsconfig when configured path does not exist' do
+          Rhales.configure do |config|
+            config.schema_tsconfig_path = '/nonexistent/tsconfig.json'
+          end
+
+          expect(Open3).to receive(:capture3)
+            .with('pnpm', 'exec', 'tsx', script_path)
+            .and_return(['{}', '', double(success?: true)])
+
+          generator.send(:execute_tsx, script_path)
+        end
+      end
+    end
   end
 end

--- a/spec/rhales/utils/schema_generator_src_spec.rb
+++ b/spec/rhales/utils/schema_generator_src_spec.rb
@@ -1,0 +1,126 @@
+# spec/rhales/utils/schema_generator_src_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'json'
+require 'fileutils'
+require 'tmpdir'
+
+RSpec.describe Rhales::SchemaGenerator do
+  describe 'external schema source handling' do
+    let(:temp_dir) { Dir.mktmpdir('rhales_schema_generator_test') }
+    let(:templates_dir) { File.join(temp_dir, 'templates') }
+    let(:output_dir) { File.join(temp_dir, 'output') }
+
+    before do
+      FileUtils.mkdir_p(templates_dir)
+      FileUtils.mkdir_p(output_dir)
+    end
+
+    after do
+      FileUtils.remove_entry(temp_dir) if File.exist?(temp_dir)
+    end
+
+    let(:inline_schema_info) do
+      {
+        template_name: 'inline_test',
+        template_path: File.join(templates_dir, 'inline_test.rue'),
+        schema_code: 'const schema = z.object({ name: z.string() });',
+        lang: 'js-zod',
+        version: nil,
+        envelope: nil,
+        window: '__DATA__',
+        merge: nil,
+        layout: nil,
+        extends: nil,
+        src: nil,
+        resolved_path: nil
+      }
+    end
+
+    let(:external_schema_info) do
+      {
+        template_name: 'external_test',
+        template_path: File.join(templates_dir, 'external_test.rue'),
+        schema_code: 'const schema = z.object({ id: z.number() });',
+        lang: 'js-zod',
+        version: nil,
+        envelope: nil,
+        window: '__DATA__',
+        merge: nil,
+        layout: nil,
+        extends: nil,
+        src: 'schemas/external.schema.ts',
+        resolved_path: File.join(templates_dir, 'schemas/external.schema.ts')
+      }
+    end
+
+    describe '#build_typescript_script (private method via send)' do
+      let(:generator) do
+        described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+      end
+
+      it 'includes inline source comment for inline schemas' do
+        script = generator.send(:build_typescript_script, inline_schema_info)
+
+        expect(script).to include('// Source: inline schema')
+        expect(script).not_to include('external')
+      end
+
+      it 'includes external source comment for external schemas' do
+        script = generator.send(:build_typescript_script, external_schema_info)
+
+        expect(script).to include('// Source: schemas/external.schema.ts (external)')
+      end
+
+      it 'includes the schema_code in the script' do
+        script = generator.send(:build_typescript_script, external_schema_info)
+
+        expect(script).to include(external_schema_info[:schema_code])
+      end
+    end
+
+    describe '#generate_schema with mocked execution' do
+      let(:generator) do
+        described_class.new(templates_dir: templates_dir, output_dir: output_dir)
+      end
+
+      let(:mock_json_schema) do
+        {
+          '$schema' => 'https://json-schema.org/draft/2020-12/schema',
+          'type' => 'object',
+          'properties' => { 'name' => { 'type' => 'string' } }
+        }
+      end
+
+      before do
+        # Mock Open3.capture3 for validation checks
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', '--version')
+          .and_return(['8.0.0', '', double(success?: true)])
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', 'exec', 'tsx', '--version')
+          .and_return(['4.0.0', '', double(success?: true)])
+        # Mock actual TypeScript execution
+        allow(Open3).to receive(:capture3)
+          .with('pnpm', 'exec', 'tsx', anything)
+          .and_return([JSON.generate(mock_json_schema), '', double(success?: true)])
+      end
+
+      it 'processes inline schemas (src: nil)' do
+        result = generator.generate_schema(inline_schema_info)
+
+        expect(result).to be_a(Hash)
+        expect(result['type']).to eq('object')
+      end
+
+      it 'processes external schemas (src present)' do
+        result = generator.generate_schema(external_schema_info)
+
+        expect(result).to be_a(Hash)
+        expect(result['type']).to eq('object')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This feature enables Rhales templates to reference schema definitions from external TypeScript/JavaScript files via a `src` attribute, rather than defining schemas inline. This supports a single-source-of-truth pattern where the same Zod schema drives both frontend TypeScript types (via `z.infer<typeof schema>`) and server-side Rhales validation.

**Example usage:**
```xml
<schema src="schemas/user.schema.ts" lang="js-zod" window="__USER__">
</schema>
```

### Key additions

- **External schema references** with path resolution relative to template files
- **Multi-directory search** via `schema_search_paths` configuration - searches template-relative first, then configured paths in order
- **tsx import mode** (`schema_use_tsx_import`) for schemas with imports - uses esbuild to bundle while externalizing zod to prevent dual-instance issues
- **Security hardening** - path traversal prevention with proper prefix attack checks, all resolved paths validated against allowed directories
- **Cross-platform support** - file:// URL conversion for Windows ESM compatibility

### Breaking changes

- Ruby 3.4+ now required (was 3.3.4)
- Removed unused `HydrationRegistry.clear!` method

### Test coverage

1,600+ new test lines across 6 new test files covering:
- Path resolution and security (traversal attacks, nested templates, edge cases)
- Multi-directory search precedence and fallback behavior
- tsx import mode with esbuild bundling and error handling
- Configuration options and freezing behavior

## Test plan

- [x] All 648 existing tests pass
- [x] New tests cover external schema extraction, bundling, and security
- [x] Manual verification of external schema resolution
- [ ] Integration test with real esbuild execution

Closes #47