### PR TITLE
Lower minimum Ruby version from 3.4 to 3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: ['3.4', '3.5']
+        ruby: ['3.2', '3.3', '3.4', '3.5']
 
     steps:
       - uses: actions/checkout@v4
@@ -50,7 +50,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: ['3.4', '3.5']
+        ruby: ['3.2', '3.3', '3.4', '3.5']
 
     steps:
       - uses: actions/checkout@v4
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.4', '3.5']
+        ruby: ['3.2', '3.3', '3.4', '3.5']
 
     steps:
       - uses: actions/checkout@v4
@@ -99,7 +99,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.4', '3.5']
+        ruby: ['3.2', '3.3', '3.4', '3.5']
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ruby-lint.yml
+++ b/.github/workflows/ruby-lint.yml
@@ -48,7 +48,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        ruby: ['3.4', '3.5']
+        ruby: ['3.2', '3.3', '3.4', '3.5']
         continue-on-error: [true]
 
     steps:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ AllCops:
   DisabledByDefault: false # flip to true for a good autocorrect time
   UseCache: true
   MaxFilesInCache: 1000
-  TargetRubyVersion: 3.4
+  TargetRubyVersion: 3.2
   Exclude:
     - 'bin/bundle'
     - 'node_modules/**/*'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Minimum Ruby version lowered from 3.4 to 3.2** - broader compatibility with stable Ruby releases; CI now exercises 3.2, 3.3, 3.4, and 3.5
+
 ## [0.6.0] - 2026-03-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Rhales is a **type-safe contract enforcement framework** for server-rendered pag
 - ✅ **External Schema References**: Reference TypeScript schema files via `src` attribute for single-source-of-truth patterns
 - ✅ **Multi-directory Search**: Configure `schema_search_paths` to search multiple directories for shared schemas
 - ✅ **tsx Import Mode**: Bundle external schemas with imports via esbuild (`schema_use_tsx_import`)
-- ✅ **Ruby 3.4+ Required**: Updated minimum Ruby version
+- ✅ **Ruby 3.2+ Supported**: Minimum Ruby version
 
 **v0.5 features:** Schema-first design, type safety, simplified API, clear context layers, schema tooling.
 

--- a/lib/rhales/parsers/rue_format_parser.rb
+++ b/lib/rhales/parsers/rue_format_parser.rb
@@ -343,7 +343,7 @@ module Rhales
     end
 
     # Preprocess content to strip XML/HTML comments outside of sections
-    # Uses Ruby 3.4+ pattern matching for robust, secure parsing
+    # Uses Ruby 3.2+ pattern matching for robust, secure parsing
     def preprocess_content(content)
       tokens = tokenize_content(content)
 

--- a/rhales.gemspec
+++ b/rhales.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.homepage              = 'https://github.com/onetimesecret/rhales'
   spec.license               = 'MIT'
-  spec.required_ruby_version = '>= 3.4'
+  spec.required_ruby_version = '>= 3.2'
 
   spec.metadata['source_code_uri']       = 'https://github.com/onetimesecret/rhales'
   spec.metadata['changelog_uri']         = 'https://github.com/onetimesecret/rhales/blob/main/CHANGELOG.md'


### PR DESCRIPTION
## Summary
Expands Ruby version compatibility by lowering the minimum required version from 3.4 to 3.2, enabling the gem to work with a broader range of stable Ruby releases.

## Changes
- **rhales.gemspec**: Updated `required_ruby_version` from `>= 3.4` to `>= 3.2`
- **CI workflows**: Extended test matrix across all CI jobs (ci.yml, ruby-lint.yml) to exercise Ruby 3.2, 3.3, 3.4, and 3.5
- **RuboCop configuration**: Updated `TargetRubyVersion` from 3.4 to 3.2 to match minimum supported version
- **Documentation**: Updated README.md and code comments to reflect 3.2+ support instead of 3.4+ requirement
- **CHANGELOG.md**: Added entry documenting the minimum version change and expanded CI coverage

## Implementation Details
All changes are configuration-only with no code modifications required. The codebase already uses Ruby 3.2-compatible syntax (pattern matching via `case/in` was introduced in Ruby 2.7). The expanded CI matrix ensures compatibility is maintained across all four supported versions.

https://claude.ai/code/session_01KRNHmBhUnRWzMYTwbHrmLX