### PR TITLE
Fix @last in {{#each}} blocks and add token-loader example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Token-cycling loader example** (`examples/token-loader.rue`): a self-contained
-  server-rendered loading animation that mimics token generation - five monospaced
-  cells scrolling through randomized hex glyphs and locking in left-to-right. CSS
-  handles all motion; randomness comes from `SecureRandom.hex` in a Ruby view
-  model. Includes `prefers-reduced-motion` fallback and accessible
-  `role="status"` markup. (#49)
+- **Server-rendered random tokens example** (`examples/token-loader.rue`):
+  pattern-teaching example showing how to generate per-request data with
+  `SecureRandom.hex` in a Ruby view model, validate a nested
+  `z.array(z.object(...))` shape, and walk it with nested `{{#each}}` blocks
+  that fall through to the current outer item without explicit bindings. The
+  original loader-animation use case is documented as a CSS-only follow-on in
+  the `<logic>` block. (#49)
 
 ### Changed
 - **Minimum Ruby version lowered from 3.4 to 3.2** - broader compatibility with stable Ruby releases; CI now exercises 3.2, 3.3, 3.4, and 3.5

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Token-cycling loader example** (`examples/token-loader.rue`): a self-contained
+  server-rendered loading animation that mimics token generation - five monospaced
+  cells scrolling through randomized hex glyphs and locking in left-to-right. CSS
+  handles all motion; randomness comes from `SecureRandom.hex` in a Ruby view
+  model. Includes `prefers-reduced-motion` fallback and accessible
+  `role="status"` markup. (#49)
+
 ### Changed
 - **Minimum Ruby version lowered from 3.4 to 3.2** - broader compatibility with stable Ruby releases; CI now exercises 3.2, 3.3, 3.4, and 3.5
+
+### Fixed
+- `{{#each}}` block variable `@last` now correctly returns `true` for the final
+  iteration instead of always `false`. Enables comma-separated output via
+  `{{#unless @last}},{{/unless}}` and similar patterns. `EachContext` now
+  accepts and stores the collection's total length.
 
 ## [0.6.0] - 2026-03-21
 

--- a/examples/token-loader.rue
+++ b/examples/token-loader.rue
@@ -1,0 +1,153 @@
+<!-- examples/token-loader.rue -->
+
+<!--
+  Example: Server-Rendered Token-Cycling Loader (O6)
+
+  A pre-boot loading animation that mimics token generation: five monospaced
+  cells, each scrolling vertically through a randomized sequence of hex
+  glyphs, locking in left-to-right onto a final character. Every page load
+  produces a unique, plausible-looking token in the loader without any
+  client JS.
+
+  Designed for the gap between the server-rendered HTML hitting the browser
+  and a SPA (Vue/React) booting -- replacing a static "Loading..." text.
+
+  Demonstrated patterns:
+  - Server-side randomness baked into the markup (SecureRandom.hex)
+  - Iteration over pre-generated arrays with {{#each}}
+  - Inline <style> with CSP nonce
+  - Accessibility: role="status" + visually-hidden label
+  - prefers-reduced-motion fallback that still shows the unique tokens
+-->
+
+<schema lang="js-zod" window="loaderTokens">
+const schema = z.object({
+  cells: z.array(z.object({
+    reel: z.array(z.string().length(1)).length(17)
+  })).length(5)
+});
+</schema>
+
+<template>
+<style nonce="{{nonce}}">
+  .ots-hash {
+    display: flex;
+    gap: .3rem;
+    font-family: ui-monospace, "SF Mono", Menlo, monospace;
+    font-size: 1.15rem;
+    line-height: 1;
+    --muted: #94a3b8;
+    --accent: #38bdf8;
+  }
+  .ots-hash .cell {
+    width: 1ch;
+    height: 1em;
+    overflow: hidden;
+    position: relative;
+    display: inline-block;
+    color: var(--muted);
+    animation: cellLock 3.6s ease-out infinite;
+  }
+  .ots-hash .reel {
+    display: block;
+    position: absolute;
+    top: 0; left: 0;
+    width: 100%;
+    text-align: center;
+    animation: reelLock 3.6s infinite;
+    animation-timing-function: steps(16, end);
+  }
+  .ots-hash .reel span {
+    display: block;
+    height: 1em;
+  }
+  /* Staggered lock-in: cells settle left-to-right. */
+  .ots-hash .cell:nth-child(1),
+  .ots-hash .cell:nth-child(1) .reel { animation-delay: 0s; }
+  .ots-hash .cell:nth-child(2),
+  .ots-hash .cell:nth-child(2) .reel { animation-delay: .18s; }
+  .ots-hash .cell:nth-child(3),
+  .ots-hash .cell:nth-child(3) .reel { animation-delay: .36s; }
+  .ots-hash .cell:nth-child(4),
+  .ots-hash .cell:nth-child(4) .reel { animation-delay: .54s; }
+  .ots-hash .cell:nth-child(5),
+  .ots-hash .cell:nth-child(5) .reel { animation-delay: .72s; }
+
+  /* Scroll past 16 glyphs in the first half, hold on the 17th (the "final"). */
+  @keyframes reelLock {
+    0%   { transform: translateY(0); }
+    50%  { transform: translateY(-16em); }
+    100% { transform: translateY(-16em); }
+  }
+  /* Color flips from muted to accent the moment the cell settles. */
+  @keyframes cellLock {
+    0%, 49%   { color: var(--muted); }
+    50%, 100% { color: var(--accent); }
+  }
+
+  .ots-hash .visually-hidden {
+    position: absolute;
+    width: 1px; height: 1px;
+    padding: 0; margin: -1px;
+    overflow: hidden;
+    clip: rect(0,0,0,0);
+    white-space: nowrap;
+    border: 0;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .ots-hash * { animation: none !important; }
+    .ots-hash .reel { transform: translateY(-16em); }  /* show final glyphs */
+    .ots-hash .cell { color: var(--accent); }
+  }
+</style>
+
+<div class="ots-hash" role="status" aria-label="Loading">
+  {{#each cells}}<span class="cell"><span class="reel">{{#each reel}}<span>{{.}}</span>{{/each}}</span></span>{{/each}}
+  <span class="visually-hidden">Loading</span>
+</div>
+</template>
+
+<logic>
+# Server-Rendered Token-Cycling Loader
+#
+# Backend Usage (Ruby):
+#
+# require 'securerandom'
+#
+# cells = Array.new(5) {
+#   { reel: Array.new(17) { SecureRandom.hex(1)[0] } }
+# }
+#
+# view = Rhales::View.new(
+#   request,
+#   client: { cells: cells },
+#   server: { pageTitle: 'Loading...' }
+# )
+#
+# html = view.render('token-loader')
+#
+# Things to get right:
+#
+# 1. Use a CSPRNG (SecureRandom), not Kernel#rand. The animation is decorative
+#    so it doesn't matter cryptographically, but SecureRandom signals intent
+#    and avoids questions about why a loader is seeded from Random.new.
+#
+# 2. Generate 5x17 = 85 fresh glyphs, don't reuse one pool across cells.
+#    Sharing chars means columns visibly rhyme, which kills the "five
+#    independent cells" effect.
+#
+# 3. Watch the cache layer. If the pre-boot shell is cached at the CDN or
+#    browser, "per-load randomness" becomes "per-cache-hit randomness."
+#    For a loader this is fine -- worst case is the same five tokens for
+#    the cache TTL, identical to a static "Loading..." string. But if a
+#    fragment cache wraps this template, exclude the .ots-hash block.
+#
+# 4. Reduced motion. The @media (prefers-reduced-motion: reduce) rule
+#    shows the final glyphs in the accent color immediately. Still server-
+#    randomized, still unique per load, just no scroll.
+#
+# 5. Accessibility. role="status" plus a visually-hidden "Loading" label
+#    means screen readers announce the state correctly without reading
+#    out 85 glyph spans.
+</logic>

--- a/examples/token-loader.rue
+++ b/examples/token-loader.rue
@@ -1,122 +1,63 @@
 <!-- examples/token-loader.rue -->
 
 <!--
-  Example: Server-Rendered Token-Cycling Loader (O6)
+  Example: Server-Rendered Random Tokens with Nested Iteration
 
-  A pre-boot loading animation that mimics token generation: five monospaced
-  cells, each scrolling vertically through a randomized sequence of hex
-  glyphs, locking in left-to-right onto a final character. Every page load
-  produces a unique, plausible-looking token in the loader without any
-  client JS.
+  Demonstrates four rhales patterns in one small template:
 
-  Designed for the gap between the server-rendered HTML hitting the browser
-  and a SPA (Vue/React) booting -- replacing a static "Loading..." text.
+  1. Generating per-request random data on the server (SecureRandom.hex)
+     and passing it to the template via the client: context, instead of
+     relying on client JavaScript to fill the page in.
 
-  Demonstrated patterns:
-  - Server-side randomness baked into the markup (SecureRandom.hex)
-  - Iteration over pre-generated arrays with {{#each}}
-  - Inline <style> with CSP nonce
-  - Accessibility: role="status" + visually-hidden label
-  - prefers-reduced-motion fallback that still shows the unique tokens
+  2. Validating a nested-array-of-objects shape with
+     z.array(z.object(...)) in the <schema> block.
+
+  3. Iterating with {{#each}} over a top-level array.
+
+  4. Iterating again inside the outer block to walk a nested array.
+     The inner {{#each}} resolves its variable name against the current
+     outer item first, so no explicit binding (`as |cell|`) or path
+     prefix (`this.glyphs`) is needed.
+
+  Each render produces a different output. The most common use case is
+  a pre-boot loader animated with CSS (see the "Use as a loader" note
+  below), but the same shape applies anywhere you want server-generated
+  per-request decorative data: identicons, correlation IDs displayed on
+  error pages, example IDs in onboarding flows, etc.
 -->
 
 <schema lang="js-zod" window="loaderTokens">
 const schema = z.object({
   cells: z.array(z.object({
-    reel: z.array(z.string().length(1)).length(17)
+    glyphs: z.array(z.string().length(1)).length(17)
   })).length(5)
 });
 </schema>
 
 <template>
 <style nonce="{{nonce}}">
-  .ots-hash {
-    display: flex;
+  .tokens {
+    display: inline-flex;
     gap: .3rem;
     font-family: ui-monospace, "SF Mono", Menlo, monospace;
-    font-size: 1.15rem;
-    line-height: 1;
-    --muted: #94a3b8;
-    --accent: #38bdf8;
-  }
-  .ots-hash .cell {
-    width: 1ch;
-    height: 1em;
-    overflow: hidden;
-    position: relative;
-    display: inline-block;
-    color: var(--muted);
-    animation: cellLock 3.6s ease-out infinite;
-  }
-  .ots-hash .reel {
-    display: block;
-    position: absolute;
-    top: 0; left: 0;
-    width: 100%;
-    text-align: center;
-    animation: reelLock 3.6s infinite;
-    animation-timing-function: steps(16, end);
-  }
-  .ots-hash .reel span {
-    display: block;
-    height: 1em;
-  }
-  /* Staggered lock-in: cells settle left-to-right. */
-  .ots-hash .cell:nth-child(1),
-  .ots-hash .cell:nth-child(1) .reel { animation-delay: 0s; }
-  .ots-hash .cell:nth-child(2),
-  .ots-hash .cell:nth-child(2) .reel { animation-delay: .18s; }
-  .ots-hash .cell:nth-child(3),
-  .ots-hash .cell:nth-child(3) .reel { animation-delay: .36s; }
-  .ots-hash .cell:nth-child(4),
-  .ots-hash .cell:nth-child(4) .reel { animation-delay: .54s; }
-  .ots-hash .cell:nth-child(5),
-  .ots-hash .cell:nth-child(5) .reel { animation-delay: .72s; }
-
-  /* Scroll past 16 glyphs in the first half, hold on the 17th (the "final"). */
-  @keyframes reelLock {
-    0%   { transform: translateY(0); }
-    50%  { transform: translateY(-16em); }
-    100% { transform: translateY(-16em); }
-  }
-  /* Color flips from muted to accent the moment the cell settles. */
-  @keyframes cellLock {
-    0%, 49%   { color: var(--muted); }
-    50%, 100% { color: var(--accent); }
-  }
-
-  .ots-hash .visually-hidden {
-    position: absolute;
-    width: 1px; height: 1px;
-    padding: 0; margin: -1px;
-    overflow: hidden;
-    clip: rect(0,0,0,0);
-    white-space: nowrap;
-    border: 0;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .ots-hash * { animation: none !important; }
-    .ots-hash .reel { transform: translateY(-16em); }  /* show final glyphs */
-    .ots-hash .cell { color: var(--accent); }
+    letter-spacing: 0.05em;
   }
 </style>
 
-<div class="ots-hash" role="status" aria-label="Loading">
-  {{#each cells}}<span class="cell"><span class="reel">{{#each reel}}<span>{{.}}</span>{{/each}}</span></span>{{/each}}
-  <span class="visually-hidden">Loading</span>
+<div class="tokens">
+  {{#each cells}}<span class="cell">{{#each glyphs}}{{.}}{{/each}}</span>{{/each}}
 </div>
 </template>
 
 <logic>
-# Server-Rendered Token-Cycling Loader
+# Server-Rendered Random Tokens
 #
 # Backend Usage (Ruby):
 #
 # require 'securerandom'
 #
 # cells = Array.new(5) {
-#   { reel: Array.new(17) { SecureRandom.hex(1)[0] } }
+#   { glyphs: Array.new(17) { SecureRandom.hex(1)[0] } }
 # }
 #
 # view = Rhales::View.new(
@@ -127,27 +68,52 @@ const schema = z.object({
 #
 # html = view.render('token-loader')
 #
-# Things to get right:
+# Why these patterns:
 #
-# 1. Use a CSPRNG (SecureRandom), not Kernel#rand. The animation is decorative
-#    so it doesn't matter cryptographically, but SecureRandom signals intent
-#    and avoids questions about why a loader is seeded from Random.new.
+# 1. Randomness lives in the view model, not the template. Rhales
+#    templates don't expose Random.new or SecureRandom directly --
+#    generate the data in Ruby and hand it to the template via the
+#    client: context. Templates stay pure-render and the data flow
+#    is explicit.
 #
-# 2. Generate 5x17 = 85 fresh glyphs, don't reuse one pool across cells.
-#    Sharing chars means columns visibly rhyme, which kills the "five
-#    independent cells" effect.
+# 2. CSPRNG over Kernel#rand. Even for decorative output, SecureRandom
+#    signals intent and avoids questions later about why a templating
+#    layer is pulling from a seeded RNG.
 #
-# 3. Watch the cache layer. If the pre-boot shell is cached at the CDN or
-#    browser, "per-load randomness" becomes "per-cache-hit randomness."
-#    For a loader this is fine -- worst case is the same five tokens for
-#    the cache TTL, identical to a static "Loading..." string. But if a
-#    fragment cache wraps this template, exclude the .ots-hash block.
+# 3. Fresh data per cell, not a shared pool. Generating 5 x 17 = 85
+#    fresh glyphs (vs. 17 glyphs shuffled five ways) avoids visible
+#    rhyming between adjacent columns.
 #
-# 4. Reduced motion. The @media (prefers-reduced-motion: reduce) rule
-#    shows the final glyphs in the accent color immediately. Still server-
-#    randomized, still unique per load, just no scroll.
+# 4. Nested {{#each}} resolves against the current outer item. Inside
+#    {{#each cells}}, the inner {{#each glyphs}} looks up "glyphs" on
+#    each cell hash automatically -- no need to write {{#each
+#    this.glyphs}} or pass an explicit binding. See
+#    lib/rhales/core/template_engine.rb EachContext#get for the
+#    fallthrough order (current item -> parent context).
 #
-# 5. Accessibility. role="status" plus a visually-hidden "Loading" label
-#    means screen readers announce the state correctly without reading
-#    out 85 glyph spans.
+# 5. Cache layer caveat. If a fragment cache wraps the response, the
+#    "fresh on every render" guarantee becomes "fresh per cache miss."
+#    Worst case is the same tokens until the cache TTL expires, which
+#    matches the behavior of a fully static template. For anything
+#    where per-request uniqueness actually matters, exclude this block
+#    from the cache.
+#
+# Use as a loader:
+#
+# The original motivation for this template was a pre-boot SPA loader
+# that "looks like" something is being computed. To wire that up, wrap
+# the output in role="status" with a visually-hidden label so screen
+# readers announce it correctly, and add CSS that scrolls each cell's
+# glyphs vertically before locking onto a final character. The 17
+# glyphs per cell are sized for a 16-step CSS animation with one
+# resting frame:
+#
+#   <div class="tokens" role="status" aria-label="Loading">
+#     ... iteration ...
+#     <span class="visually-hidden">Loading</span>
+#   </div>
+#
+# The animation itself is just CSS keyframes on the iterated spans and
+# is independent of rhales -- the rhales-specific work ends at
+# rendering the markup with fresh random characters per request.
 </logic>

--- a/lib/rhales/core/template_engine.rb
+++ b/lib/rhales/core/template_engine.rb
@@ -202,9 +202,11 @@ module Rhales
       items = get_variable_value(items_var)
 
       if items.respond_to?(:each)
-        items.map.with_index do |item, index|
+        items_array = items.to_a
+        total       = items_array.size
+        items_array.map.with_index do |item, index|
           # Create context for each iteration
-          item_context = create_each_context(item, index, items_var)
+          item_context = create_each_context(item, index, items_var, total)
           engine       = self.class.new('', item_context, partial_resolver: @partial_resolver)
           engine.send(:render_content_nodes, block_content)
         end.join
@@ -312,8 +314,8 @@ module Rhales
     end
 
     # Create context for each iteration
-    def create_each_context(item, index, items_var)
-      EachContext.new(@context, item, index, items_var)
+    def create_each_context(item, index, items_var, total = nil)
+      EachContext.new(@context, item, index, items_var, total)
     end
 
     # HTML escape for XSS protection
@@ -323,13 +325,14 @@ module Rhales
 
     # Context wrapper for {{#each}} iterations
     class EachContext
-      attr_reader :parent_context, :current_item, :current_index, :items_var
+      attr_reader :parent_context, :current_item, :current_index, :items_var, :total
 
-      def initialize(parent_context, current_item, current_index, items_var)
+      def initialize(parent_context, current_item, current_index, items_var, total = nil)
         @parent_context = parent_context
         @current_item   = current_item
         @current_index  = current_index
         @items_var      = items_var
+        @total          = total
       end
 
       def get(variable_name)
@@ -342,8 +345,7 @@ module Rhales
         when '@first'
           return @current_index == 0
         when '@last'
-          # We'd need to know the total length for this
-          return false
+          return @total ? @current_index == @total - 1 : false
         end
 
         # Check if it's a property of the current item

--- a/spec/rhales/core/template_engine_each_block_spec.rb
+++ b/spec/rhales/core/template_engine_each_block_spec.rb
@@ -1,0 +1,65 @@
+# spec/rhales/core/template_engine_each_block_spec.rb
+#
+# frozen_string_literal: true
+
+require_relative '../../spec_helper'
+
+RSpec.describe Rhales::TemplateEngine, '{{#each}} block variables' do
+  def render(template, client)
+    context = Rhales::Context.minimal(client: client)
+    Rhales::TemplateEngine.new(template, context).render
+  end
+
+  describe '@last' do
+    it 'is true only for the final element' do
+      template = '{{#each items}}{{this}}={{#if @last}}LAST{{/if}}|{{/each}}'
+      output   = render(template, items: %w[a b c])
+
+      expect(output).to eq('a=|b=|c=LAST|')
+    end
+
+    it 'enables comma-separated output via {{#unless @last}}' do
+      template = '{{#each items}}{{this}}{{#unless @last}},{{/unless}}{{/each}}'
+      output   = render(template, items: %w[a b c])
+
+      expect(output).to eq('a,b,c')
+    end
+
+    it 'reflects the inner loop in nested {{#each}} blocks' do
+      template = '{{#each rows}}[{{#each this}}{{.}}{{#unless @last}}-{{/unless}}{{/each}}]{{/each}}'
+      output   = render(template, rows: [%w[a b], %w[c d e]])
+
+      expect(output).to eq('[a-b][c-d-e]')
+    end
+
+    it 'is true for the only element in a single-item collection' do
+      template = '{{#each items}}{{#if @last}}only{{/if}}{{/each}}'
+      output   = render(template, items: ['x'])
+
+      expect(output).to eq('only')
+    end
+
+    it 'is false for all elements when none is last (empty collection)' do
+      template = 'start{{#each items}}{{#if @last}}!{{/if}}{{/each}}end'
+      output   = render(template, items: [])
+
+      expect(output).to eq('startend')
+    end
+  end
+
+  describe '@first and @index (regression)' do
+    it 'still reports @first correctly alongside @last' do
+      template = '{{#each items}}{{#if @first}}F{{/if}}{{this}}{{#if @last}}L{{/if}}|{{/each}}'
+      output   = render(template, items: %w[a b c])
+
+      expect(output).to eq('Fa|b|cL|')
+    end
+
+    it 'still exposes @index' do
+      template = '{{#each items}}{{@index}}:{{this}} {{/each}}'
+      output   = render(template, items: %w[a b c])
+
+      expect(output).to eq('0:a 1:b 2:c ')
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Fixes the `@last` block variable in `{{#each}}` iterations to correctly return `true` for the final element, and adds a comprehensive example demonstrating server-rendered random tokens with nested iteration.

## Changes

### Fixed
- **`@last` block variable** now correctly evaluates to `true` for the final iteration instead of always returning `false`
  - `EachContext` now accepts and stores the collection's total length
  - `render_each_block` calculates total items and passes it to `create_each_context`
  - Enables patterns like `{{#unless @last}},{{/unless}}` for comma-separated output

### Added
- **`examples/token-loader.rue`**: Pattern-teaching example showing:
  - Server-side random data generation with `SecureRandom.hex` passed via the `client:` context
  - Nested array-of-objects validation with `z.array(z.object(...))`
  - Nested `{{#each}}` blocks that resolve variables against the current outer item without explicit bindings
  - Comprehensive documentation of the use case (pre-boot loader animation) and implementation rationale
  - Notes on caching implications and accessibility patterns

- **`spec/rhales/core/template_engine_each_block_spec.rb`**: Test suite covering:
  - `@last` correctness in single and multi-item collections
  - `@last` behavior in nested `{{#each}}` blocks
  - Regression tests for `@first` and `@index` alongside `@last`
  - Empty collection edge case

### Updated
- **CHANGELOG.md**: Documented the fix and new example with issue reference

## Implementation Details
The fix required minimal changes to the existing `EachContext` class:
- Convert enumerable to array and calculate size before iteration
- Pass total length to `EachContext` constructor
- Update `@last` evaluation to compare `current_index == total - 1`

The example demonstrates the fallthrough resolution order in nested contexts: when `{{#each glyphs}}` appears inside `{{#each cells}}`, the inner loop automatically resolves `glyphs` against the current cell without requiring `this.glyphs` or explicit bindings.

https://claude.ai/code/session_01VvPm3UpRAEaVz592qvtFgh