### PR TITLE
Bump version to 0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.1] - 2026-05-25
+
 ### Added
 - **Server-rendered random tokens example** (`examples/token-loader.rue`):
   pattern-teaching example showing how to generate per-request data with

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rhales (0.6.0)
+    rhales (0.6.1)
       json_schemer (~> 2)
       logger
       tilt (~> 2)

--- a/lib/rhales/version.rb
+++ b/lib/rhales/version.rb
@@ -5,6 +5,6 @@
 module Rhales
   # Version information for the RSFC gem
   unless defined?(Rhales::VERSION)
-    VERSION = '0.6.0'
+    VERSION = '0.6.1'
   end
 end


### PR DESCRIPTION
## Summary
- Bump `Rhales::VERSION` to `0.6.1`
- Promote the `[Unreleased]` CHANGELOG section to `[0.6.1] - 2026-05-25`
- Update `Gemfile.lock` via `bundle install`

Captures the changes already merged since 0.6.0:
- `{{#each}}` `@last` fix (#49)
- Minimum Ruby lowered to 3.2 (#50)
- Server-rendered token-loader example (#49)

## Test plan
- [ ] `bundle exec rspec spec/rhales/`
- [ ] `gem build rhales.gemspec` produces `rhales-0.6.1.gem`

https://claude.ai/code/session_019U2kzxpcn372cd3LqN5v2Q

---
_Generated by [Claude Code](https://claude.ai/code/session_019U2kzxpcn372cd3LqN5v2Q)_