### PR TITLE
Bump unicode-emoji to 4.2.0 for Ruby 4.x compat; release 0.6.2

### DIFF
--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -132,7 +132,10 @@ jobs:
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           bundler-cache: true
-          ruby-version: ruby   # latest stable Ruby installed by setup-ruby
+          # Pinned to a Ruby version exercised by .github/workflows/ci.yml so
+          # releases are built with a known-good interpreter. Bump in step with
+          # the CI matrix.
+          ruby-version: '3.4'
 
       - name: Verify release tag matches Rhales::VERSION
         env:

--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -132,10 +132,7 @@ jobs:
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           bundler-cache: true
-          # Pinned to a Ruby version exercised by .github/workflows/ci.yml so
-          # releases are built with a known-good interpreter. Bump in step with
-          # the CI matrix.
-          ruby-version: '3.4'
+          ruby-version: ruby   # latest stable Ruby installed by setup-ruby
 
       - name: Verify release tag matches Rhales::VERSION
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-05-25
+
+### Added
+- **Automated gem release workflow** (`.github/workflows/release-gem.yml`):
+  builds and publishes the gem to RubyGems.org via Trusted Publishing
+  (OIDC) whenever a GitHub Release is published with a `vMAJOR.MINOR.PATCH`
+  tag. Verifies the tag matches `Rhales::VERSION` before pushing.
+
+### Changed
+- **Dependencies**: bumped `unicode-emoji` from 4.0.4 to 4.2.0 and
+  `unicode-display_width` from 3.1.4 to 3.2.0. The previous
+  `unicode-emoji` cap of `< Ruby 4.0` broke `bundle install` on Ruby 4.x;
+  4.2.0 lifts that cap.
+- **Gemfile.lock**: platform list normalized via
+  `bundle lock --normalize-platforms` so platform-specific gems no longer
+  trigger setup-ruby warnings on CI.
+
 ## [0.6.1] - 2026-05-25
 
 ### Added

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rhales (0.6.1)
+    rhales (0.6.2)
       json_schemer (~> 2)
       logger
       tilt (~> 2)
@@ -153,14 +153,14 @@ GEM
       prettier_print (>= 1.2.0)
     tilt (2.6.1)
     tsort (0.2.0)
-    unicode-display_width (3.1.4)
-      unicode-emoji (~> 4.0, >= 4.0.4)
-    unicode-emoji (4.0.4)
+    unicode-display_width (3.2.0)
+      unicode-emoji (~> 4.1)
+    unicode-emoji (4.2.0)
     yard (0.9.37)
     zeitwerk (2.7.3)
 
 PLATFORMS
-  arm64-darwin-24
+  arm64-darwin
   ruby
 
 DEPENDENCIES
@@ -186,4 +186,4 @@ DEPENDENCIES
   yard (~> 0.9)
 
 BUNDLED WITH
-   2.6.6
+   2.7.2

--- a/lib/rhales/version.rb
+++ b/lib/rhales/version.rb
@@ -5,6 +5,6 @@
 module Rhales
   # Version information for the RSFC gem
   unless defined?(Rhales::VERSION)
-    VERSION = '0.6.1'
+    VERSION = '0.6.2'
   end
 end


### PR DESCRIPTION
## Summary

The first run of the new `release-gem` workflow failed because `ruby-version: ruby` selected Ruby 4.0.5, and the lockfile pinned `unicode-emoji 4.0.4` which caps `required_ruby_version` at `< 4.0`. `bundler-cache: true` then aborted `bundle install` before the build/push could run.

Rather than papering over it by pinning the workflow's Ruby version, this PR fixes the underlying incompatibility.

## Root-cause changes

- **`unicode-emoji` 4.0.4 → 4.2.0** (released 2025-12-17). 4.2.0 drops the `< 4.0` Ruby cap (`>= 2.5` only). Pulled in transitively via `rubocop → unicode-display_width`.
- **`unicode-display_width` 3.1.4 → 3.2.0** — the line that loosens its `unicode-emoji` requirement to `~> 4.1`.
- **`bundle lock --normalize-platforms`** — addresses the secondary setup-ruby warning about platform-specific gems in the lockfile.
- **`Rhales::VERSION` 0.6.1 → 0.6.2** — the v0.6.1 GitHub release tag is immutable from the failed publish, so the next release needs a new tag.
- **CHANGELOG.md** — adds 0.6.2 entry covering the release workflow (already on main) and the dependency bumps.

The release workflow itself returns to its post-#54 state — no `ruby-version` pin; `ruby-version: ruby` will track the latest stable per the canonical RubyGems Trusted Publishing template.

## Validation

- `bundle install` on Ruby 3.3.6 ✓
- Full RSpec suite: **661 examples, 0 failures** ✓
- `gem build rhales.gemspec` produces `rhales-0.6.2.gem` ✓

## Follow-up

Once merged, draft a `v0.6.2` GitHub release to exercise the publish pipeline end-to-end. The one-time trusted-publisher and `rubygems.org` environment setup described at the top of `.github/workflows/release-gem.yml` still needs to be completed on RubyGems.org and in repo settings before the workflow can actually push.

https://claude.ai/code/session_01D9uYUatKduDNHr6rCmDgzX

---
_Generated by [Claude Code](https://claude.ai/code/session_01D9uYUatKduDNHr6rCmDgzX)_