### PR TITLE
Fix JSONP callback XSS and harden JSON-in-HTML/JS escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   such as `alert(1)//`. Callback names are now validated against a JavaScript
   identifier / dotted member-path pattern and an invalid name raises
   `ArgumentError` before any template data is processed.
+- **JSON-in-HTML/JS escaping** (`Rhales::JSONSerializer.dump_html_safe`): standard
+  JSON generation does not escape `<`, `>`, `&`, U+2028 or U+2029, so hydration
+  data containing `</script>` could break out of the surrounding script context
+  and inject markup/JavaScript (XSS). The new `dump_html_safe` escapes those
+  characters as `\uXXXX` (equivalent JSON that round-trips identically) and is now
+  used for the HTML hydration `<script type="application/json">` data block
+  (`View`) and the ES module / JSONP endpoint bodies (`HydrationEndpoint`).
 
 ## [0.6.2] - 2026-05-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- **JSONP callback name validation** (`Rhales::HydrationEndpoint#render_jsonp`):
+  the caller-supplied callback name was reflected verbatim into the executable
+  response body, allowing arbitrary JavaScript injection (XSS) via a payload
+  such as `alert(1)//`. Callback names are now validated against a JavaScript
+  identifier / dotted member-path pattern and an invalid name raises
+  `ArgumentError` before any template data is processed.
+
 ## [0.6.2] - 2026-05-25
 
 ### Added

--- a/lib/rhales/core/view.rb
+++ b/lib/rhales/core/view.rb
@@ -390,7 +390,7 @@ module Rhales
         # Create JSON script tag with optional reflection attributes
         json_attrs = reflection_enabled? ? " data-window=\"#{window_attr}\"" : ''
         json_script = <<~HTML.strip
-          <script#{nonce_attr} id="#{unique_id}" type="application/json"#{json_attrs}>#{JSONSerializer.dump(data)}</script>
+          <script#{nonce_attr} id="#{unique_id}" type="application/json"#{json_attrs}>#{JSONSerializer.dump_html_safe(data)}</script>
         HTML
 
         # Create hydration script with optional reflection attributes

--- a/lib/rhales/hydration/hydration_endpoint.rb
+++ b/lib/rhales/hydration/hydration_endpoint.rb
@@ -98,7 +98,7 @@ module Rhales
       merged_data = process_template_data(template_name, additional_context)
 
       {
-        content: "export default #{JSONSerializer.dump(merged_data)};",
+        content: "export default #{JSONSerializer.dump_html_safe(merged_data)};",
         content_type: 'text/javascript',
         headers: module_headers(merged_data)
       }
@@ -117,7 +117,7 @@ module Rhales
       merged_data = process_template_data(template_name, additional_context)
 
       {
-        content: "#{callback_name}(#{JSONSerializer.dump(merged_data)});",
+        content: "#{callback_name}(#{JSONSerializer.dump_html_safe(merged_data)});",
         content_type: 'application/javascript',
         headers: jsonp_headers(merged_data),
       }

--- a/lib/rhales/hydration/hydration_endpoint.rb
+++ b/lib/rhales/hydration/hydration_endpoint.rb
@@ -42,6 +42,11 @@ module Rhales
   # module_response = endpoint.render_module('template_name')
   # ```
   class HydrationEndpoint
+    # Valid JSONP callback names: a JS identifier or dotted member path
+    # (e.g. "handleData", "app.callbacks.handleData"). Anything outside this
+    # set could break out of the callback invocation and inject script.
+    CALLBACK_NAME_PATTERN = /\A[a-zA-Z_$][a-zA-Z0-9_$.]*\z/
+
     def initialize(config, context = nil)
       @config = config
       @context = context
@@ -100,7 +105,15 @@ module Rhales
     end
 
     # Render JSONP response with callback
+    #
+    # The callback name is reflected directly into the executable response
+    # body, so it must be validated before use. Without validation a caller
+    # supplying something like "alert(1)//" would inject arbitrary JavaScript.
     def render_jsonp(template_name, callback_name, additional_context = {})
+      unless callback_name.is_a?(String) && callback_name.match?(CALLBACK_NAME_PATTERN)
+        raise ArgumentError, "Invalid callback: #{callback_name.inspect}"
+      end
+
       merged_data = process_template_data(template_name, additional_context)
 
       {

--- a/lib/rhales/hydration/hydration_endpoint.rb
+++ b/lib/rhales/hydration/hydration_endpoint.rb
@@ -43,9 +43,12 @@ module Rhales
   # ```
   class HydrationEndpoint
     # Valid JSONP callback names: a JS identifier or dotted member path
-    # (e.g. "handleData", "app.callbacks.handleData"). Anything outside this
-    # set could break out of the callback invocation and inject script.
-    CALLBACK_NAME_PATTERN = /\A[a-zA-Z_$][a-zA-Z0-9_$.]*\z/
+    # (e.g. "handleData", "app.callbacks.handleData"). Each dotted segment must
+    # be its own valid identifier, so malformed paths like "foo.", "foo..bar"
+    # or "foo.1bar" are rejected rather than producing unusable JSONP. Anything
+    # outside this set could break out of the callback invocation and inject
+    # script.
+    CALLBACK_NAME_PATTERN = /\A[a-zA-Z_$][a-zA-Z0-9_$]*(?:\.[a-zA-Z_$][a-zA-Z0-9_$]*)*\z/
 
     def initialize(config, context = nil)
       @config = config

--- a/lib/rhales/utils/json_serializer.rb
+++ b/lib/rhales/utils/json_serializer.rb
@@ -32,6 +32,19 @@ module Rhales
   #   # => :oj (if available) or :json (stdlib)
   #
   module JSONSerializer
+    # Characters that can terminate an HTML <script> element or, in legacy
+    # JavaScript engines, a string literal. They are escaped as \uXXXX, which
+    # is equivalent JSON/JS and round-trips identically through any parser.
+    HTML_ESCAPE = {
+      '<' => '\u003c',
+      '>' => '\u003e',
+      '&' => '\u0026',
+      "\u2028" => '\u2028',
+      "\u2029" => '\u2029',
+    }.freeze
+
+    HTML_ESCAPE_PATTERN = /[<>&  ]/
+
     class << self
       # Serialize Ruby object to JSON string
       #
@@ -42,6 +55,22 @@ module Rhales
       # @raise [TypeError] if object contains non-serializable types
       def dump(obj)
         @json_dumper.call(obj)
+      end
+
+      # Serialize Ruby object to a JSON string safe to embed in an HTML
+      # <script> element or a JavaScript resource body.
+      #
+      # Standard JSON generation does not escape <, >, & or the U+2028/U+2029
+      # line separators, so a value containing "</script>" would break out of
+      # the surrounding script context and allow markup/JavaScript injection
+      # (XSS). This method escapes those characters as \uXXXX. The result is
+      # still valid JSON and parses back to the identical value.
+      #
+      # @param obj [Object] Ruby object to serialize
+      # @return [String] HTML/JS-context-safe JSON string
+      # @raise [TypeError] if object contains non-serializable types
+      def dump_html_safe(obj)
+        dump(obj).gsub(HTML_ESCAPE_PATTERN, HTML_ESCAPE)
       end
 
       # Serialize Ruby object to pretty-printed JSON string

--- a/spec/rhales/hydration_endpoint_spec.rb
+++ b/spec/rhales/hydration_endpoint_spec.rb
@@ -295,6 +295,8 @@ RSpec.describe Rhales::HydrationEndpoint do
           'foo()',
           '<script>alert(1)</script>',
           "foo\nbar",
+          "foo\r\nbar",
+          "foo\0bar",
           'foo-bar',
           'foo[0]',
           'foo+bar'

--- a/spec/rhales/hydration_endpoint_spec.rb
+++ b/spec/rhales/hydration_endpoint_spec.rb
@@ -265,6 +265,63 @@ RSpec.describe Rhales::HydrationEndpoint do
 
       endpoint.render_jsonp(template_name, callback_name, additional_context)
     end
+
+    context 'callback name validation (XSS protection)' do
+      it 'accepts a simple function name' do
+        expect { endpoint.render_jsonp(template_name, 'handleData') }.not_to raise_error
+      end
+
+      it 'accepts a namespaced callback' do
+        result = endpoint.render_jsonp(template_name, 'app.callbacks.handleData')
+        expect(result[:content]).to start_with('app.callbacks.handleData(')
+      end
+
+      it 'accepts callbacks containing $, underscores and digits' do
+        ['jQuery_12345', '_private', '$callback', 'cb1'].each do |name|
+          expect { endpoint.render_jsonp(template_name, name) }.not_to raise_error
+        end
+      end
+
+      it 'rejects a callback that injects arbitrary JavaScript' do
+        expect { endpoint.render_jsonp(template_name, 'alert(1)//') }
+          .to raise_error(ArgumentError, /Invalid callback/)
+      end
+
+      it 'rejects callbacks containing dangerous characters' do
+        malicious = [
+          'alert(document.cookie)',
+          'foo;bar',
+          'foo bar',
+          'foo()',
+          '<script>alert(1)</script>',
+          "foo\nbar",
+          'foo-bar',
+          'foo[0]',
+          'foo+bar'
+        ]
+
+        malicious.each do |name|
+          expect { endpoint.render_jsonp(template_name, name) }
+            .to raise_error(ArgumentError, /Invalid callback/), "expected #{name.inspect} to be rejected"
+        end
+      end
+
+      it 'rejects an empty callback name' do
+        expect { endpoint.render_jsonp(template_name, '') }
+          .to raise_error(ArgumentError, /Invalid callback/)
+      end
+
+      it 'rejects a callback beginning with a digit' do
+        expect { endpoint.render_jsonp(template_name, '1callback') }
+          .to raise_error(ArgumentError, /Invalid callback/)
+      end
+
+      it 'does not process template data when the callback is invalid' do
+        expect(endpoint).not_to receive(:process_template_data)
+        expect { endpoint.render_jsonp(template_name, 'alert(1)//') }
+          .to raise_error(ArgumentError)
+      end
+    end
   end
 
   describe '#data_changed?' do

--- a/spec/rhales/hydration_endpoint_spec.rb
+++ b/spec/rhales/hydration_endpoint_spec.rb
@@ -228,6 +228,19 @@ RSpec.describe Rhales::HydrationEndpoint do
 
       endpoint.render_module(template_name, additional_context)
     end
+
+    it 'escapes characters that could break out of the script context' do
+      allow(endpoint).to receive(:process_template_data)
+        .and_return({ 'x' => '</script><script>alert(1)</script>' })
+
+      result = endpoint.render_module(template_name)
+
+      expect(result[:content]).not_to include('</script>')
+      expect(result[:content]).not_to include('<script>')
+      # Data still round-trips to the original value
+      json = result[:content].sub(/\Aexport default /, '').sub(/;\z/, '')
+      expect(JSON.parse(json)['x']).to eq('</script><script>alert(1)</script>')
+    end
   end
 
   describe '#render_jsonp' do
@@ -323,6 +336,19 @@ RSpec.describe Rhales::HydrationEndpoint do
         expect { endpoint.render_jsonp(template_name, 'alert(1)//') }
           .to raise_error(ArgumentError)
       end
+    end
+
+    it 'escapes characters in data that could break out of the script context' do
+      allow(endpoint).to receive(:process_template_data)
+        .and_return({ 'x' => '</script><script>alert(1)</script>' })
+
+      result = endpoint.render_jsonp(template_name, callback_name)
+
+      expect(result[:content]).not_to include('</script>')
+      expect(result[:content]).not_to include('<script>')
+      # Data still round-trips to the original value
+      json = result[:content].sub(/\A#{callback_name}\(/, '').sub(/\);\z/, '')
+      expect(JSON.parse(json)['x']).to eq('</script><script>alert(1)</script>')
     end
   end
 

--- a/spec/rhales/hydration_endpoint_spec.rb
+++ b/spec/rhales/hydration_endpoint_spec.rb
@@ -331,6 +331,15 @@ RSpec.describe Rhales::HydrationEndpoint do
           .to raise_error(ArgumentError, /Invalid callback/)
       end
 
+      it 'rejects malformed dotted member paths' do
+        # Each dotted segment must be its own valid JS identifier; these pass a
+        # naive character-class check but produce unusable JSONP like foo.(...).
+        ['foo.', 'foo..bar', 'foo.1bar', '.foo', 'foo.bar.'].each do |name|
+          expect { endpoint.render_jsonp(template_name, name) }
+            .to raise_error(ArgumentError, /Invalid callback/), "expected #{name.inspect} to be rejected"
+        end
+      end
+
       it 'does not process template data when the callback is invalid' do
         expect(endpoint).not_to receive(:process_template_data)
         expect { endpoint.render_jsonp(template_name, 'alert(1)//') }

--- a/spec/rhales/integration/hydration_html_escaping_spec.rb
+++ b/spec/rhales/integration/hydration_html_escaping_spec.rb
@@ -1,0 +1,47 @@
+# spec/rhales/integration/hydration_html_escaping_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'fileutils'
+
+RSpec.describe 'hydration HTML escaping (XSS protection)' do
+  let(:templates_dir) { File.join(__dir__, '../../fixtures/templates/hydration_escape_test') }
+
+  before do
+    FileUtils.mkdir_p(templates_dir)
+  end
+
+  after do
+    FileUtils.rm_rf(templates_dir)
+  end
+
+  it 'escapes </script> in client data so it cannot break out of the data block' do
+    File.write(File.join(templates_dir, 'escape.rue'), <<~RUE)
+      <schema lang="js-zod" window="appState">
+      const schema = z.object({ note: z.string() });
+      </schema>
+
+      <template>
+      <div>page</div>
+      </template>
+    RUE
+
+    config = Rhales::Configuration.new do |c|
+      c.template_paths = [templates_dir]
+    end
+
+    payload = '</script><img src=x onerror=alert(1)>'
+    view = Rhales::View.new(nil, client: { note: payload }, config: config)
+    html = view.render('escape')
+
+    # The raw breakout sequence must not appear anywhere in the rendered HTML.
+    expect(html).not_to include('</script><img')
+    expect(html).not_to include('<img src=x onerror=alert(1)>')
+
+    # The escaped data must still round-trip to the original value for the client.
+    data_match = html.match(%r{<script[^>]*id="rsfc-data-[^"]+"\s+type="application/json"[^>]*>(.*?)</script>}m)
+    expect(data_match).not_to be_nil
+    expect(JSON.parse(data_match[1])['note']).to eq(payload)
+  end
+end

--- a/spec/rhales/json_serializer_spec.rb
+++ b/spec/rhales/json_serializer_spec.rb
@@ -58,6 +58,47 @@ RSpec.describe Rhales::JSONSerializer do
     end
   end
 
+  describe '.dump_html_safe' do
+    it 'escapes characters that can break out of an HTML <script> element' do
+      data = { 'x' => '</script><script>alert(1)</script>' }
+      result = described_class.dump_html_safe(data)
+
+      expect(result).not_to include('</script>')
+      expect(result).not_to include('<script>')
+      expect(result).to include('<')
+      expect(result).to include('>')
+    end
+
+    it 'escapes ampersands' do
+      result = described_class.dump_html_safe({ 'x' => 'a & b' })
+
+      expect(result).not_to include('&')
+      expect(result).to include('&')
+    end
+
+    it 'escapes the U+2028 and U+2029 line separators' do
+      data = { 'x' => "a b c" }
+      result = described_class.dump_html_safe(data)
+
+      expect(result).not_to include(" ")
+      expect(result).not_to include(" ")
+      expect(result).to include('\u2028')
+      expect(result).to include('\u2029')
+    end
+
+    it 'round-trips: escaped output parses back to the original data' do
+      data = { 'x' => '</script>', 'amp' => 'a & b', 'sep' => "a b c" }
+      result = described_class.dump_html_safe(data)
+
+      expect(described_class.parse(result)).to eq(data)
+    end
+
+    it 'leaves data without dangerous characters identical to .dump' do
+      data = { 'user' => 'Alice', 'count' => 42, 'nested' => { 'a' => [1, 2] } }
+      expect(described_class.dump_html_safe(data)).to eq(described_class.dump(data))
+    end
+  end
+
   describe '.pretty_dump' do
     it 'serializes with pretty formatting' do
       data = { 'user' => 'Alice', 'count' => 42 }

--- a/spec/rhales/json_serializer_spec.rb
+++ b/spec/rhales/json_serializer_spec.rb
@@ -65,15 +65,15 @@ RSpec.describe Rhales::JSONSerializer do
 
       expect(result).not_to include('</script>')
       expect(result).not_to include('<script>')
-      expect(result).to include('<')
-      expect(result).to include('>')
+      expect(result).to include('\u003c')
+      expect(result).to include('\u003e')
     end
 
     it 'escapes ampersands' do
       result = described_class.dump_html_safe({ 'x' => 'a & b' })
 
       expect(result).not_to include('&')
-      expect(result).to include('&')
+      expect(result).to include('\u0026')
     end
 
     it 'escapes the U+2028 and U+2029 line separators' do


### PR DESCRIPTION
## Summary

Fixes two reflected-XSS vectors in the hydration layer.

### 1. JSONP callback name injection (C4)
`HydrationEndpoint#render_jsonp` reflected the caller-supplied `callback_name` verbatim into the executable response body:

```ruby
content: "#{callback_name}(#{JSONSerializer.dump(merged_data)});"
```

A caller passing `alert(1)//` (reachable via `View#render_jsonp_only`) injected arbitrary JavaScript. Callback names are now validated against a JS identifier / dotted member-path pattern (`CALLBACK_NAME_PATTERN`) and an invalid name raises `ArgumentError` **before** any template data is processed.

### 2. JSON-in-HTML/JS escaping
`JSONSerializer.dump` does not escape `<`, `>`, `&`, U+2028 or U+2029. When that output is embedded into an HTML `<script>` element or a JS resource body, a value containing `</script>` breaks out of the script context and injects markup/JavaScript. Added `JSONSerializer.dump_html_safe`, which escapes those characters as `\uXXXX` — equivalent JSON that round-trips to the identical value — and applied it at the three executable/HTML sinks:

- `View` hydration data block: `<script type="application/json">…</script>`
- `HydrationEndpoint#render_module`: `export default …;`
- `HydrationEndpoint#render_jsonp`: `callback(…);`

`render_json` (served `application/json`, not HTML/executable) and the ETag hashes (canonical data) are intentionally left on plain `dump`.

## Testing
- TDD throughout: failing tests committed first, then implementation.
- New coverage: callback-name validation (valid names, malicious payloads, CRLF/null-byte, empty, leading-digit), `dump_html_safe` unit specs (escaping + round-trip), endpoint escaping specs, and an integration spec proving `</script>` in client data breaks out of the rendered hydration block before the fix.
- Full suite: **677 examples, 0 failures**.
- RuboCop: no new offenses introduced.

## Notes
- Behavior change: previously-accepted-but-malformed JSONP callbacks now raise `ArgumentError` (a 400-class condition) rather than emitting broken JS.
- `CHANGELOG.md` updated under `### Security`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01RW6R2GXoefeaSqTSFKYh88)_