### PR TITLE
Fix unescaped window attribute XSS and CSP nonce logging (#57)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -37,6 +37,10 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Fall back to a current model when the action's default model id is
+          # unavailable (the previous default 404s: "model: claude-sonnet-4-20250514")
+          fallback_model: "claude-sonnet-4-6"
+
           # Direct prompt for automated review (no @claude mention needed)
           direct_prompt: |
             Please review this pull request and provide feedback on:

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -36,6 +36,10 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Fall back to a current model when the action's default model id is
+          # unavailable (the previous default 404s: "model: claude-sonnet-4-20250514")
+          fallback_model: "claude-sonnet-4-6"
+
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
             actions: read

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+- Validate the schema `window` attribute against a JavaScript identifier pattern
+  (`/\A[a-zA-Z_][a-zA-Z0-9_]*\z/`) at parse time; invalid names raise
+  `RueDocument::ParseError` (#57).
+- Escape the window name at every hydration render site as defense in depth:
+  HTML-escape it in `data-window` / `data-hydration-target` attributes and
+  JSON-encode it (`JSONSerializer.dump_html_safe`) in `window[...]` script
+  contexts, in both `View` and `LinkBasedInjectionDetector`. Previously an
+  unescaped window name could break out of the HTML attribute or JS string (#57).
+- Stop logging the raw CSP nonce value. `CSP.generate_nonce` and
+  `CSP#build_header` now log only length/entropy/usage metadata, never the
+  per-response secret itself (#57).
+
 ## [0.7.0] - 2026-06-21
 
 ### Security

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Stop logging the raw CSP nonce value. `CSP.generate_nonce` and
   `CSP#build_header` now log only length/entropy/usage metadata, never the
   per-response secret itself (#57).
+- Escape the remaining interpolated config values in `LinkBasedInjectionDetector`
+  for the same reason: `endpoint_url` / `template_name` (HTML-escaped in `href` /
+  `data-lazy-src`, JSON-encoded in `fetch(...)` / `import` / loader calls) and the
+  lazy `mount_selector` (JSON-encoded in `document.querySelector(...)`), so a
+  single/double quote in those config values can no longer break out of its
+  context (#59 review).
 
 ## [0.7.0] - 2026-06-21
 

--- a/lib/rhales/core/rue_document.rb
+++ b/lib/rhales/core/rue_document.rb
@@ -41,6 +41,11 @@ module Rhales
     # Known schema section attributes
     KNOWN_SCHEMA_ATTRIBUTES = %w[lang version envelope window merge layout extends src].freeze
 
+    # The window attribute names a global JavaScript property and is interpolated
+    # into HTML attribute and <script> contexts during hydration. Restrict it to a
+    # valid JavaScript identifier so it cannot break out of either context (issue #57).
+    WINDOW_ATTRIBUTE_PATTERN = /\A[a-zA-Z_][a-zA-Z0-9_]*\z/
+
     attr_reader :content, :file_path, :grammar, :ast
 
     def initialize(content, file_path = nil)
@@ -289,6 +294,7 @@ module Rhales
         validate_schema_attributes!
         # Set default window attribute for schema section
         @schema_attributes['window'] ||= 'data'
+        validate_window_attribute!
 
         # Schema sections require lang attribute
         unless @schema_attributes['lang']
@@ -303,6 +309,15 @@ module Rhales
       unknown_attributes.each do |attr|
         warn_unknown_schema_attribute(attr)
       end
+    end
+
+    def validate_window_attribute!
+      window = @schema_attributes['window']
+      return if window.is_a?(String) && window.match?(WINDOW_ATTRIBUTE_PATTERN)
+
+      raise ParseError,
+        "Invalid window attribute #{window.inspect}: must be a valid JavaScript " \
+        "identifier matching #{WINDOW_ATTRIBUTE_PATTERN.source}"
     end
 
     def warn_unknown_schema_attribute(attribute)

--- a/lib/rhales/core/view.rb
+++ b/lib/rhales/core/view.rb
@@ -387,26 +387,31 @@ module Rhales
         unique_id = "rsfc-data-#{SecureRandom.hex(8)}"
         nonce_attr = nonce_attribute
 
+        # Escape the window name for its two output contexts (issue #57). Parse-time
+        # validation already restricts it to a JS identifier; this is defense in depth.
+        window_attr_html = ERB::Util.html_escape(window_attr)
+        window_attr_js   = JSONSerializer.dump_html_safe(window_attr)
+
         # Create JSON script tag with optional reflection attributes
-        json_attrs = reflection_enabled? ? " data-window=\"#{window_attr}\"" : ''
+        json_attrs = reflection_enabled? ? " data-window=\"#{window_attr_html}\"" : ''
         json_script = <<~HTML.strip
           <script#{nonce_attr} id="#{unique_id}" type="application/json"#{json_attrs}>#{JSONSerializer.dump_html_safe(data)}</script>
         HTML
 
         # Create hydration script with optional reflection attributes
-        hydration_attrs = reflection_enabled? ? " data-hydration-target=\"#{window_attr}\"" : ''
+        hydration_attrs = reflection_enabled? ? " data-hydration-target=\"#{window_attr_html}\"" : ''
         hydration_script = if reflection_enabled?
           <<~HTML.strip
             <script#{nonce_attr}#{hydration_attrs}>
             var dataScript = document.getElementById('#{unique_id}');
-            var targetName = dataScript.getAttribute('data-window') || '#{window_attr}';
+            var targetName = dataScript.getAttribute('data-window') || #{window_attr_js};
             window[targetName] = JSON.parse(dataScript.textContent);
             </script>
           HTML
         else
           <<~HTML.strip
             <script#{nonce_attr}#{hydration_attrs}>
-            window['#{window_attr}'] = JSON.parse(document.getElementById('#{unique_id}').textContent);
+            window[#{window_attr_js}] = JSON.parse(document.getElementById('#{unique_id}').textContent);
             </script>
           HTML
         end

--- a/lib/rhales/hydration/link_based_injection_detector.rb
+++ b/lib/rhales/hydration/link_based_injection_detector.rb
@@ -3,7 +3,9 @@
 # frozen_string_literal: true
 
 require 'strscan'
+require 'erb'
 require_relative 'safe_injection_validator'
+require_relative '../utils/json_serializer'
 
 module Rhales
   # Generates link-based hydration strategies that use browser resource hints
@@ -47,12 +49,14 @@ module Rhales
 
     def generate_basic_link(template_name, window_attr, nonce)
       endpoint_url = "#{@api_endpoint_path}/#{template_name}"
+      window_attr_html = ERB::Util.html_escape(window_attr)
+      window_attr_js   = JSONSerializer.dump_html_safe(window_attr)
 
       link_tag = %(<link href="#{endpoint_url}" type="application/json">)
 
       script_tag = <<~HTML.strip
-        <script#{nonce_attribute(nonce)} data-hydration-target="#{window_attr}">
-        // Load hydration data for #{window_attr}
+        <script#{nonce_attribute(nonce)} data-hydration-target="#{window_attr_html}">
+        // Load hydration data
         window.__rhales__ = window.__rhales__ || {};
         if (!window.__rhales__.loadData) {
           window.__rhales__.loadData = function(target, url) {
@@ -61,7 +65,7 @@ module Rhales
               .then(data => window[target] = data);
           };
         }
-        window.__rhales__.loadData('#{window_attr}', '#{endpoint_url}');
+        window.__rhales__.loadData(#{window_attr_js}, '#{endpoint_url}');
         </script>
       HTML
 
@@ -71,12 +75,14 @@ module Rhales
     def generate_prefetch_link(template_name, window_attr, nonce)
       endpoint_url = "#{@api_endpoint_path}/#{template_name}"
       crossorigin_attr = @crossorigin_enabled ? ' crossorigin' : ''
+      window_attr_html = ERB::Util.html_escape(window_attr)
+      window_attr_js   = JSONSerializer.dump_html_safe(window_attr)
 
       link_tag = %(<link rel="prefetch" href="#{endpoint_url}" as="fetch"#{crossorigin_attr}>)
 
       script_tag = <<~HTML.strip
-        <script#{nonce_attribute(nonce)} data-hydration-target="#{window_attr}">
-        // Prefetch hydration data for #{window_attr}
+        <script#{nonce_attribute(nonce)} data-hydration-target="#{window_attr_html}">
+        // Prefetch hydration data
         window.__rhales__ = window.__rhales__ || {};
         if (!window.__rhales__.loadPrefetched) {
           window.__rhales__.loadPrefetched = function(target, url) {
@@ -85,7 +91,7 @@ module Rhales
               .then(data => window[target] = data);
           };
         }
-        window.__rhales__.loadPrefetched('#{window_attr}', '#{endpoint_url}');
+        window.__rhales__.loadPrefetched(#{window_attr_js}, '#{endpoint_url}');
         </script>
       HTML
 
@@ -95,19 +101,21 @@ module Rhales
     def generate_preload_link(template_name, window_attr, nonce)
       endpoint_url = "#{@api_endpoint_path}/#{template_name}"
       crossorigin_attr = @crossorigin_enabled ? ' crossorigin' : ''
+      window_attr_html = ERB::Util.html_escape(window_attr)
+      window_attr_js   = JSONSerializer.dump_html_safe(window_attr)
 
       link_tag = %(<link rel="preload" href="#{endpoint_url}" as="fetch"#{crossorigin_attr}>)
 
       script_tag = <<~HTML.strip
-        <script#{nonce_attribute(nonce)} data-hydration-target="#{window_attr}">
+        <script#{nonce_attribute(nonce)} data-hydration-target="#{window_attr_html}">
         // Preload strategy - high priority fetch
         fetch('#{endpoint_url}')
           .then(r => r.json())
           .then(data => {
-            window['#{window_attr}'] = data;
+            window[#{window_attr_js}] = data;
             // Dispatch ready event
             window.dispatchEvent(new CustomEvent('rhales:hydrated', {
-              detail: { target: '#{window_attr}', data: data }
+              detail: { target: #{window_attr_js}, data: data }
             }));
           })
           .catch(err => console.error('Rhales hydration error:', err));
@@ -119,18 +127,20 @@ module Rhales
 
     def generate_modulepreload_link(template_name, window_attr, nonce)
       endpoint_url = "#{@api_endpoint_path}/#{template_name}.js"
+      window_attr_html = ERB::Util.html_escape(window_attr)
+      window_attr_js   = JSONSerializer.dump_html_safe(window_attr)
 
       link_tag = %(<link rel="modulepreload" href="#{endpoint_url}">)
 
       script_tag = <<~HTML.strip
-        <script type="module"#{nonce_attribute(nonce)} data-hydration-target="#{window_attr}">
+        <script type="module"#{nonce_attribute(nonce)} data-hydration-target="#{window_attr_html}">
         // Module preload strategy
         import data from '#{endpoint_url}';
-        window['#{window_attr}'] = data;
+        window[#{window_attr_js}] = data;
 
         // Dispatch ready event
         window.dispatchEvent(new CustomEvent('rhales:hydrated', {
-          detail: { target: '#{window_attr}', data: data }
+          detail: { target: #{window_attr_js}, data: data }
         }));
         </script>
       HTML
@@ -141,10 +151,12 @@ module Rhales
     def generate_lazy_loading(template_name, window_attr, nonce)
       endpoint_url = "#{@api_endpoint_path}/#{template_name}"
       mount_selector = @hydration_config.lazy_mount_selector || '#app'
+      window_attr_html = ERB::Util.html_escape(window_attr)
+      window_attr_js   = JSONSerializer.dump_html_safe(window_attr)
 
       # No link tag for lazy loading - purely script-driven
       script_tag = <<~HTML.strip
-        <script#{nonce_attribute(nonce)} data-hydration-target="#{window_attr}" data-lazy-src="#{endpoint_url}">
+        <script#{nonce_attribute(nonce)} data-hydration-target="#{window_attr_html}" data-lazy-src="#{endpoint_url}">
         // Lazy loading strategy with intersection observer
         window.__rhales__ = window.__rhales__ || {};
         window.__rhales__.initLazyLoading = function() {
@@ -160,9 +172,9 @@ module Rhales
                 fetch('#{endpoint_url}')
                   .then(r => r.json())
                   .then(data => {
-                    window['#{window_attr}'] = data;
+                    window[#{window_attr_js}] = data;
                     window.dispatchEvent(new CustomEvent('rhales:hydrated', {
-                      detail: { target: '#{window_attr}', data: data }
+                      detail: { target: #{window_attr_js}, data: data }
                     }));
                   })
                   .catch(err => console.error('Rhales lazy hydration error:', err));

--- a/lib/rhales/hydration/link_based_injection_detector.rb
+++ b/lib/rhales/hydration/link_based_injection_detector.rb
@@ -51,8 +51,10 @@ module Rhales
       endpoint_url = "#{@api_endpoint_path}/#{template_name}"
       window_attr_html = ERB::Util.html_escape(window_attr)
       window_attr_js   = JSONSerializer.dump_html_safe(window_attr)
+      endpoint_url_html = ERB::Util.html_escape(endpoint_url)
+      endpoint_url_js   = JSONSerializer.dump_html_safe(endpoint_url)
 
-      link_tag = %(<link href="#{endpoint_url}" type="application/json">)
+      link_tag = %(<link href="#{endpoint_url_html}" type="application/json">)
 
       script_tag = <<~HTML.strip
         <script#{nonce_attribute(nonce)} data-hydration-target="#{window_attr_html}">
@@ -65,7 +67,7 @@ module Rhales
               .then(data => window[target] = data);
           };
         }
-        window.__rhales__.loadData(#{window_attr_js}, '#{endpoint_url}');
+        window.__rhales__.loadData(#{window_attr_js}, #{endpoint_url_js});
         </script>
       HTML
 
@@ -77,8 +79,10 @@ module Rhales
       crossorigin_attr = @crossorigin_enabled ? ' crossorigin' : ''
       window_attr_html = ERB::Util.html_escape(window_attr)
       window_attr_js   = JSONSerializer.dump_html_safe(window_attr)
+      endpoint_url_html = ERB::Util.html_escape(endpoint_url)
+      endpoint_url_js   = JSONSerializer.dump_html_safe(endpoint_url)
 
-      link_tag = %(<link rel="prefetch" href="#{endpoint_url}" as="fetch"#{crossorigin_attr}>)
+      link_tag = %(<link rel="prefetch" href="#{endpoint_url_html}" as="fetch"#{crossorigin_attr}>)
 
       script_tag = <<~HTML.strip
         <script#{nonce_attribute(nonce)} data-hydration-target="#{window_attr_html}">
@@ -91,7 +95,7 @@ module Rhales
               .then(data => window[target] = data);
           };
         }
-        window.__rhales__.loadPrefetched(#{window_attr_js}, '#{endpoint_url}');
+        window.__rhales__.loadPrefetched(#{window_attr_js}, #{endpoint_url_js});
         </script>
       HTML
 
@@ -103,13 +107,15 @@ module Rhales
       crossorigin_attr = @crossorigin_enabled ? ' crossorigin' : ''
       window_attr_html = ERB::Util.html_escape(window_attr)
       window_attr_js   = JSONSerializer.dump_html_safe(window_attr)
+      endpoint_url_html = ERB::Util.html_escape(endpoint_url)
+      endpoint_url_js   = JSONSerializer.dump_html_safe(endpoint_url)
 
-      link_tag = %(<link rel="preload" href="#{endpoint_url}" as="fetch"#{crossorigin_attr}>)
+      link_tag = %(<link rel="preload" href="#{endpoint_url_html}" as="fetch"#{crossorigin_attr}>)
 
       script_tag = <<~HTML.strip
         <script#{nonce_attribute(nonce)} data-hydration-target="#{window_attr_html}">
         // Preload strategy - high priority fetch
-        fetch('#{endpoint_url}')
+        fetch(#{endpoint_url_js})
           .then(r => r.json())
           .then(data => {
             window[#{window_attr_js}] = data;
@@ -129,13 +135,15 @@ module Rhales
       endpoint_url = "#{@api_endpoint_path}/#{template_name}.js"
       window_attr_html = ERB::Util.html_escape(window_attr)
       window_attr_js   = JSONSerializer.dump_html_safe(window_attr)
+      endpoint_url_html = ERB::Util.html_escape(endpoint_url)
+      endpoint_url_js   = JSONSerializer.dump_html_safe(endpoint_url)
 
-      link_tag = %(<link rel="modulepreload" href="#{endpoint_url}">)
+      link_tag = %(<link rel="modulepreload" href="#{endpoint_url_html}">)
 
       script_tag = <<~HTML.strip
         <script type="module"#{nonce_attribute(nonce)} data-hydration-target="#{window_attr_html}">
         // Module preload strategy
-        import data from '#{endpoint_url}';
+        import data from #{endpoint_url_js};
         window[#{window_attr_js}] = data;
 
         // Dispatch ready event
@@ -153,23 +161,26 @@ module Rhales
       mount_selector = @hydration_config.lazy_mount_selector || '#app'
       window_attr_html = ERB::Util.html_escape(window_attr)
       window_attr_js   = JSONSerializer.dump_html_safe(window_attr)
+      endpoint_url_html = ERB::Util.html_escape(endpoint_url)
+      endpoint_url_js   = JSONSerializer.dump_html_safe(endpoint_url)
+      mount_selector_js = JSONSerializer.dump_html_safe(mount_selector)
 
       # No link tag for lazy loading - purely script-driven
       script_tag = <<~HTML.strip
-        <script#{nonce_attribute(nonce)} data-hydration-target="#{window_attr_html}" data-lazy-src="#{endpoint_url}">
+        <script#{nonce_attribute(nonce)} data-hydration-target="#{window_attr_html}" data-lazy-src="#{endpoint_url_html}">
         // Lazy loading strategy with intersection observer
         window.__rhales__ = window.__rhales__ || {};
         window.__rhales__.initLazyLoading = function() {
-          const mountElement = document.querySelector('#{mount_selector}');
+          const mountElement = document.querySelector(#{mount_selector_js});
           if (!mountElement) {
-            console.warn('Rhales: Mount element "#{mount_selector}" not found for lazy loading');
+            console.warn('Rhales: Mount element ' + #{mount_selector_js} + ' not found for lazy loading');
             return;
           }
 
           const observer = new IntersectionObserver((entries) => {
             entries.forEach(entry => {
               if (entry.isIntersecting) {
-                fetch('#{endpoint_url}')
+                fetch(#{endpoint_url_js})
                   .then(r => r.json())
                   .then(data => {
                     window[#{window_attr_js}] = data;

--- a/lib/rhales/security/csp.rb
+++ b/lib/rhales/security/csp.rb
@@ -47,10 +47,10 @@ module Rhales
 
       header = policy_directives.join('; ')
 
-      # Log CSP header generation for security audit
+      # Log CSP header generation for security audit. The nonce is a per-response
+      # secret, so log only whether one was used, never its value (issue #57).
       log_with_metadata(Rhales.logger, :debug, "CSP header generated",
         nonce_used: nonce_used,
-        nonce: @nonce,
         directive_count: policy_directives.size,
         header_length: header.length
       )
@@ -62,8 +62,9 @@ module Rhales
     def self.generate_nonce
       nonce = SecureRandom.hex(16)
 
-      # Log nonce generation for security audit trail
-      Rhales.logger.debug("CSP nonce generated: nonce=#{nonce} length=#{nonce.length} entropy_bits=#{nonce.length * 4}")
+      # Log nonce generation for security audit trail. Never log the nonce value
+      # itself — it is a per-response secret (issue #57).
+      Rhales.logger.debug("CSP nonce generated: length=#{nonce.length} entropy_bits=#{nonce.length * 4}")
 
       nonce
     end

--- a/spec/rhales/enhanced_hydration_injector_spec.rb
+++ b/spec/rhales/enhanced_hydration_injector_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe Rhales::HydrationInjector do
 
         expect(result).to include('<link rel="modulepreload" href="/api/hydration/test_template.js">')
         expect(result).to include('type="module"')
-        expect(result).to include('import data from \'/api/hydration/test_template.js\'')
+        expect(result).to include('import data from "/api/hydration/test_template.js"')
       end
     end
 
@@ -247,7 +247,7 @@ RSpec.describe Rhales::HydrationInjector do
         expect(result).to include('data-hydration-target="apiData"')
 
         # Should have multiple fetch calls
-        expect(result.scan(/fetch\('\/api\/hydration\/test_template'\)/).length).to eq(3)
+        expect(result.scan(/fetch\("\/api\/hydration\/test_template"\)/).length).to eq(3)
       end
     end
   end

--- a/spec/rhales/hydration_strategies_integration_spec.rb
+++ b/spec/rhales/hydration_strategies_integration_spec.rb
@@ -270,8 +270,8 @@ RSpec.describe 'Hydration Strategies Integration' do
 
         # Should have immediate fetch scripts
         expect(result).to include('fetch(\'/api/hydration/react_app\')')
-        expect(result).to include("window['userData'] = data;")
-        expect(result).to include("window['appConfig'] = data;")
+        expect(result).to include('window["userData"] = data;')
+        expect(result).to include('window["appConfig"] = data;')
 
         # Should include nonce for CSP compliance
         expect(result).to include('nonce="test-nonce-abc123"')
@@ -319,8 +319,8 @@ RSpec.describe 'Hydration Strategies Integration' do
         expect(result).to include('<link rel="modulepreload" href="/api/hydration/react_app.js">')
         expect(result).to include('type="module"')
         expect(result).to include('import data from \'/api/hydration/react_app.js\';')
-        expect(result).to include("window['userData'] = data;")
-        expect(result).to include("window['appConfig'] = data;")
+        expect(result).to include('window["userData"] = data;')
+        expect(result).to include('window["appConfig"] = data;')
       end
     end
 
@@ -359,8 +359,8 @@ RSpec.describe 'Hydration Strategies Integration' do
 
         expect(result).to include('<link href="/api/hydration/vue_app" type="application/json">')
         expect(result).to include('loadData')  # Manual loading function
-        expect(result).to include('window.__rhales__.loadData(\'userData\', \'/api/hydration/vue_app\');')  # Calls load function
-        expect(result).to include('window.__rhales__.loadData(\'appConfig\', \'/api/hydration/vue_app\');')  # Calls load function
+        expect(result).to include('window.__rhales__.loadData("userData", \'/api/hydration/vue_app\');')  # Calls load function
+        expect(result).to include('window.__rhales__.loadData("appConfig", \'/api/hydration/vue_app\');')  # Calls load function
         expect(result).not_to include('window.userData = data;')  # No automatic assignment
       end
     end

--- a/spec/rhales/hydration_strategies_integration_spec.rb
+++ b/spec/rhales/hydration_strategies_integration_spec.rb
@@ -269,7 +269,7 @@ RSpec.describe 'Hydration Strategies Integration' do
         expect(result).to include('data-hydration-target="appConfig"')
 
         # Should have immediate fetch scripts
-        expect(result).to include('fetch(\'/api/hydration/react_app\')')
+        expect(result).to include('fetch("/api/hydration/react_app")')
         expect(result).to include('window["userData"] = data;')
         expect(result).to include('window["appConfig"] = data;')
 
@@ -318,7 +318,7 @@ RSpec.describe 'Hydration Strategies Integration' do
 
         expect(result).to include('<link rel="modulepreload" href="/api/hydration/react_app.js">')
         expect(result).to include('type="module"')
-        expect(result).to include('import data from \'/api/hydration/react_app.js\';')
+        expect(result).to include('import data from "/api/hydration/react_app.js";')
         expect(result).to include('window["userData"] = data;')
         expect(result).to include('window["appConfig"] = data;')
       end
@@ -334,7 +334,7 @@ RSpec.describe 'Hydration Strategies Integration' do
 
         expect(result).to include('IntersectionObserver')
         expect(result).to include('data-lazy-src="/api/hydration/complex_spa"')
-        expect(result).to include('querySelector(\'#app\')')  # Default mount selector
+        expect(result).to include('querySelector("#app")')  # Default mount selector
         expect(result).to include('entry.isIntersecting')
         expect(result).not_to include('<link rel="prefetch"')  # No preload links for lazy
       end
@@ -345,7 +345,7 @@ RSpec.describe 'Hydration Strategies Integration' do
 
         result = injector.inject_link_based_strategy(complex_spa_template, merged_data, nonce)
 
-        expect(result).to include('querySelector(\'.app-container\')')
+        expect(result).to include('querySelector(".app-container")')
       end
     end
 
@@ -359,8 +359,8 @@ RSpec.describe 'Hydration Strategies Integration' do
 
         expect(result).to include('<link href="/api/hydration/vue_app" type="application/json">')
         expect(result).to include('loadData')  # Manual loading function
-        expect(result).to include('window.__rhales__.loadData("userData", \'/api/hydration/vue_app\');')  # Calls load function
-        expect(result).to include('window.__rhales__.loadData("appConfig", \'/api/hydration/vue_app\');')  # Calls load function
+        expect(result).to include('window.__rhales__.loadData("userData", "/api/hydration/vue_app");')  # Calls load function
+        expect(result).to include('window.__rhales__.loadData("appConfig", "/api/hydration/vue_app");')  # Calls load function
         expect(result).not_to include('window.userData = data;')  # No automatic assignment
       end
     end

--- a/spec/rhales/link_based_injection_detector_spec.rb
+++ b/spec/rhales/link_based_injection_detector_spec.rb
@@ -65,7 +65,7 @@ RSpec.describe Rhales::LinkBasedInjectionDetector do
         expect(result).to include('data-hydration-target="myData"')
         expect(result).to include('nonce="test-nonce-123"')
         expect(result).to include('fetch(\'/api/hydration/test_template\')')
-        expect(result).to include("window['myData'] = data")
+        expect(result).to include('window["myData"] = data')
         expect(result).to include('rhales:hydrated')
       end
 
@@ -85,7 +85,7 @@ RSpec.describe Rhales::LinkBasedInjectionDetector do
         expect(result).to include('data-hydration-target="myData"')
         expect(result).to include('nonce="test-nonce-123"')
         expect(result).to include('import data from \'/api/hydration/test_template.js\'')
-        expect(result).to include("window['myData'] = data")
+        expect(result).to include('window["myData"] = data')
         expect(result).to include('rhales:hydrated')
       end
 
@@ -174,14 +174,14 @@ RSpec.describe Rhales::LinkBasedInjectionDetector do
         result = detector.generate_for_strategy(:preload, template_name, 'userData', nonce)
 
         expect(result).to include('data-hydration-target="userData"')
-        expect(result).to include("window['userData'] = data")
+        expect(result).to include('window["userData"] = data')
       end
 
       it 'handles snake_case window attributes' do
         result = detector.generate_for_strategy(:preload, template_name, 'user_data', nonce)
 
         expect(result).to include('data-hydration-target="user_data"')
-        expect(result).to include("window['user_data'] = data")
+        expect(result).to include('window["user_data"] = data')
       end
     end
 
@@ -197,7 +197,7 @@ RSpec.describe Rhales::LinkBasedInjectionDetector do
           result = detector.generate_for_strategy(strategy, template_name, window_attr, nonce)
 
           expect(result).to include('window.dispatchEvent(new CustomEvent(\'rhales:hydrated\'')
-          expect(result).to include('detail: { target: \'myData\', data: data }')
+          expect(result).to include('detail: { target: "myData", data: data }')
         end
       end
 
@@ -216,8 +216,11 @@ RSpec.describe Rhales::LinkBasedInjectionDetector do
           malicious_window_attr = "userData; alert('XSS')"
           result = detector.generate_for_strategy(:preload, template_name, malicious_window_attr, nonce)
 
-          # Should use bracket notation, not dot notation
-          expect(result).to include("window['#{malicious_window_attr}']")
+          # Window name is JSON-encoded (double-quoted), so the injected single
+          # quote cannot break out of the string literal.
+          encoded = Rhales::JSONSerializer.dump_html_safe(malicious_window_attr)
+          expect(result).to include("window[#{encoded}]")
+          expect(result).not_to include("window['#{malicious_window_attr}']")
           expect(result).not_to include("window.#{malicious_window_attr}")
         end
 
@@ -235,7 +238,7 @@ RSpec.describe Rhales::LinkBasedInjectionDetector do
             result = detector.generate_for_strategy(strategy, template_name, 'testAttr', nonce)
 
             # These strategies should use bracket notation for direct assignments
-            expect(result).to include("window['testAttr']")
+            expect(result).to include('window["testAttr"]')
           end
 
           # Link and prefetch strategies use dynamic assignment via function calls
@@ -266,7 +269,7 @@ RSpec.describe Rhales::LinkBasedInjectionDetector do
         it 'handles empty string window attributes' do
           result = detector.generate_for_strategy(:preload, template_name, '', nonce)
 
-          expect(result).to include("window['']")
+          expect(result).to include('window[""]')
         end
       end
     end

--- a/spec/rhales/link_based_injection_detector_spec.rb
+++ b/spec/rhales/link_based_injection_detector_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe Rhales::LinkBasedInjectionDetector do
         expect(result).to include('<link rel="preload" href="/api/hydration/test_template" as="fetch" crossorigin>')
         expect(result).to include('data-hydration-target="myData"')
         expect(result).to include('nonce="test-nonce-123"')
-        expect(result).to include('fetch(\'/api/hydration/test_template\')')
+        expect(result).to include('fetch("/api/hydration/test_template")')
         expect(result).to include('window["myData"] = data')
         expect(result).to include('rhales:hydrated')
       end
@@ -84,7 +84,7 @@ RSpec.describe Rhales::LinkBasedInjectionDetector do
         expect(result).to include('type="module"')
         expect(result).to include('data-hydration-target="myData"')
         expect(result).to include('nonce="test-nonce-123"')
-        expect(result).to include('import data from \'/api/hydration/test_template.js\'')
+        expect(result).to include('import data from "/api/hydration/test_template.js"')
         expect(result).to include('window["myData"] = data')
         expect(result).to include('rhales:hydrated')
       end
@@ -105,14 +105,14 @@ RSpec.describe Rhales::LinkBasedInjectionDetector do
         expect(result).to include('data-lazy-src="/api/hydration/test_template"')
         expect(result).to include('nonce="test-nonce-123"')
         expect(result).to include('IntersectionObserver')
-        expect(result).to include('document.querySelector(\'#app\')')
+        expect(result).to include('document.querySelector("#app")')
       end
 
       it 'respects configured mount selector' do
         hydration_config.lazy_mount_selector = '#main-content'
         result = detector.generate_for_strategy(:lazy, template_name, window_attr, nonce)
 
-        expect(result).to include('document.querySelector(\'#main-content\')')
+        expect(result).to include('document.querySelector("#main-content")')
       end
 
       it 'handles DOM ready states' do

--- a/spec/rhales/logging_spec.rb
+++ b/spec/rhales/logging_spec.rb
@@ -233,21 +233,24 @@ RSpec.describe 'Rhales Logging' do
       config.csp_enabled = true
     end
 
-    it 'logs nonce generation' do
-      Rhales::CSP.generate_nonce
+    it 'logs nonce generation metadata without the nonce value' do
+      nonce = Rhales::CSP.generate_nonce
 
       expect(logger).to have_received(:debug).with(
-        a_string_matching(/CSP nonce generated: nonce=\w+/),
+        a_string_matching(/CSP nonce generated: length=\d+ entropy_bits=\d+/),
       )
+      # The raw nonce is a per-response secret and must never be logged (issue #57)
+      expect(logger).not_to have_received(:debug).with(a_string_including(nonce))
     end
 
-    it 'logs CSP header generation' do
-      csp = Rhales::CSP.new(config, nonce: 'test-nonce')
+    it 'logs CSP header generation without the nonce value' do
+      csp = Rhales::CSP.new(config, nonce: 'test-nonce-secret')
       csp.build_header
 
       expect(logger).to have_received(:debug).with(
         a_string_matching(/CSP header generated: nonce_used=true/),
       )
+      expect(logger).not_to have_received(:debug).with(a_string_including('test-nonce-secret'))
     end
   end
 

--- a/spec/rhales/security/window_attribute_injection_spec.rb
+++ b/spec/rhales/security/window_attribute_injection_spec.rb
@@ -132,6 +132,42 @@ RSpec.describe 'window attribute injection (issue #57)' do
     end
   end
 
+  describe 'config-value escaping in link_based_injection_detector.rb (#59 review)' do
+    let(:hydration_config) do
+      cfg = Rhales::HydrationConfiguration.new
+      cfg.api_endpoint_path = '/api/hydration'
+      cfg
+    end
+    let(:detector) { Rhales::LinkBasedInjectionDetector.new(hydration_config) }
+
+    it 'JSON-encodes endpoint_url (built from template_name) in JS string contexts' do
+      malicious_template = "tpl'];alert(1);//"
+      result = detector.generate_for_strategy(:preload, malicious_template, 'data', nil)
+
+      endpoint_url = "/api/hydration/#{malicious_template}"
+      encoded = Rhales::JSONSerializer.dump_html_safe(endpoint_url)
+      expect(result).to include("fetch(#{encoded})")
+      expect(result).not_to include("fetch('#{endpoint_url}')")
+    end
+
+    it 'HTML-escapes endpoint_url in the link href attribute' do
+      hydration_config.api_endpoint_path = '/api/h"x'
+      result = detector.generate_for_strategy(:preload, 'tpl', 'data', nil)
+
+      expect(result).not_to include('href="/api/h"x/tpl"')
+      expect(result).to include('href="/api/h&quot;x/tpl"')
+    end
+
+    it 'JSON-encodes mount_selector in document.querySelector' do
+      hydration_config.lazy_mount_selector = "[data-app='main']"
+      result = detector.generate_for_strategy(:lazy, 'tpl', 'data', nil)
+
+      encoded = Rhales::JSONSerializer.dump_html_safe("[data-app='main']")
+      expect(result).to include("document.querySelector(#{encoded})")
+      expect(result).not_to include("document.querySelector('[data-app='main']')")
+    end
+  end
+
   describe 'CSP nonce is not written to the debug log (L-1)' do
     let(:logger) { instance_double(Logger, debug: nil, info: nil, warn: nil, error: nil) }
 

--- a/spec/rhales/security/window_attribute_injection_spec.rb
+++ b/spec/rhales/security/window_attribute_injection_spec.rb
@@ -1,0 +1,158 @@
+# spec/rhales/security/window_attribute_injection_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'erb'
+
+# Regression coverage for issue #57:
+#   - H-1: `window` attribute interpolated unescaped into HTML attribute and
+#          JavaScript string contexts in view.rb and link_based_injection_detector.rb
+#   - L-1: CSP nonce value written to the debug log (csp.rb generate_nonce + build_header)
+RSpec.describe 'window attribute injection (issue #57)' do
+  describe 'parse-time validation (primary defense)' do
+    def parse(window_value)
+      rue = <<~RUE
+        <schema lang="js-zod" window=#{window_value.inspect}>
+        const schema = z.object({ a: z.string() });
+        </schema>
+
+        <template>
+        <div>page</div>
+        </template>
+      RUE
+      doc = Rhales::RueDocument.new(rue)
+      doc.parse!
+      doc
+    end
+
+    it 'accepts valid JavaScript identifiers' do
+      %w[data appState __ONETIME_STATE__ user_data myData _x x9].each do |name|
+        expect { parse(name) }.not_to raise_error
+        expect(parse(name).schema_window).to eq(name)
+      end
+    end
+
+    it 'rejects a window name that breaks out of a single-quoted JS string' do
+      expect { parse("x'];alert(1);//") }
+        .to raise_error(Rhales::RueDocument::ParseError, /window/i)
+    end
+
+    it 'rejects a window name that breaks out of an HTML attribute' do
+      expect { parse('x"><script>alert(1)</script>') }
+        .to raise_error(Rhales::RueDocument::ParseError, /window/i)
+    end
+
+    it 'rejects a window name containing whitespace' do
+      expect { parse('a b') }.to raise_error(Rhales::RueDocument::ParseError, /window/i)
+    end
+
+    it 'rejects a window name that does not start with a letter or underscore' do
+      expect { parse('9bad') }.to raise_error(Rhales::RueDocument::ParseError, /window/i)
+    end
+  end
+
+  describe 'view.rb render-site escaping (defense in depth)' do
+    let(:config) { Rhales::Configuration.new }
+    let(:view) { Rhales::View.new(nil, config: config) }
+    let(:js_breakout) { "x'];alert(1);//" }
+    let(:attr_breakout) { 'x"><script>alert(1)</script>' }
+
+    context 'with reflection enabled (default)' do
+      it 'HTML-escapes the window name in data-window / data-hydration-target attributes' do
+        html = view.send(:generate_hydration_from_merged_data, { attr_breakout => { 'a' => 1 } })
+
+        escaped = ERB::Util.html_escape(attr_breakout)
+        expect(html).to include(%(data-window="#{escaped}"))
+        expect(html).to include(%(data-hydration-target="#{escaped}"))
+        expect(html).not_to include(%(data-window="#{attr_breakout}"))
+        expect(html).not_to include('<script>alert(1)</script>')
+      end
+
+      it 'JSON-encodes the window name in the targetName fallback string' do
+        html = view.send(:generate_hydration_from_merged_data, { js_breakout => { 'a' => 1 } })
+
+        encoded = Rhales::JSONSerializer.dump_html_safe(js_breakout)
+        expect(html).to include("|| #{encoded};")
+        expect(html).not_to include("|| '#{js_breakout}'")
+      end
+    end
+
+    context 'with reflection disabled' do
+      before { config.hydration.reflection_enabled = false }
+
+      it 'JSON-encodes the window name in the window[...] assignment' do
+        html = view.send(:generate_hydration_from_merged_data, { js_breakout => { 'a' => 1 } })
+
+        encoded = Rhales::JSONSerializer.dump_html_safe(js_breakout)
+        expect(html).to include("window[#{encoded}]")
+        expect(html).not_to include("window['#{js_breakout}']")
+      end
+    end
+  end
+
+  describe 'link_based_injection_detector.rb render-site escaping (defense in depth)' do
+    let(:hydration_config) do
+      cfg = Rhales::HydrationConfiguration.new
+      cfg.api_endpoint_path = '/api/hydration'
+      cfg
+    end
+    let(:detector) { Rhales::LinkBasedInjectionDetector.new(hydration_config) }
+    let(:js_breakout) { "x'];alert(1);//" }
+    let(:attr_breakout) { 'x"><script>alert(1)</script>' }
+
+    [:preload, :modulepreload, :lazy].each do |strategy|
+      it "JSON-encodes the window name in window[...] assignment for #{strategy}" do
+        result = detector.generate_for_strategy(strategy, 'tpl', js_breakout, nil)
+
+        encoded = Rhales::JSONSerializer.dump_html_safe(js_breakout)
+        expect(result).to include("window[#{encoded}]")
+        expect(result).not_to include("window['#{js_breakout}']")
+      end
+    end
+
+    [:link, :prefetch, :preload, :modulepreload, :lazy].each do |strategy|
+      it "HTML-escapes the window name in data-hydration-target for #{strategy}" do
+        result = detector.generate_for_strategy(strategy, 'tpl', attr_breakout, nil)
+
+        escaped = ERB::Util.html_escape(attr_breakout)
+        expect(result).to include(%(data-hydration-target="#{escaped}"))
+        expect(result).not_to include(%(data-hydration-target="#{attr_breakout}"))
+      end
+    end
+
+    it 'uses static JS comments that never embed the window name (no comment breakout)' do
+      { link: '// Load hydration data', prefetch: '// Prefetch hydration data' }.each do |strategy, comment|
+        result = detector.generate_for_strategy(strategy, 'tpl', 'sentinelWindow', nil)
+        comment_line = result.lines.find { |line| line.strip.start_with?(comment) }
+
+        expect(comment_line).not_to be_nil
+        expect(comment_line.strip).to eq(comment)
+      end
+    end
+  end
+
+  describe 'CSP nonce is not written to the debug log (L-1)' do
+    let(:logger) { instance_double(Logger, debug: nil, info: nil, warn: nil, error: nil) }
+
+    before { Rhales.logger = logger }
+    after { Rhales.logger = nil }
+
+    it 'does not log the raw nonce value when generating a nonce' do
+      nonce = Rhales::CSP.generate_nonce
+
+      expect(logger).to have_received(:debug).with(a_string_matching(/CSP nonce generated/))
+      expect(logger).not_to have_received(:debug).with(a_string_including(nonce))
+    end
+
+    it 'does not log the raw nonce value when building a header' do
+      config = Rhales::Configuration.new
+      config.csp_enabled = true
+      secret = 'supersecretnoncevalue'
+
+      Rhales::CSP.new(config, nonce: secret).build_header
+
+      expect(logger).not_to have_received(:debug).with(a_string_including(secret))
+    end
+  end
+end


### PR DESCRIPTION
Closes #57.

Addresses the two open findings from the security review in issue #57 (re-verified against `main` `089d4e6`). The third finding (JSONP callback reflection) was already fixed on `main`.

## H-1 — `window` attribute interpolated unescaped into HTML/JS contexts

The schema `window` attribute name was interpolated **unescaped** into HTML attribute values (`data-window="…"`, `data-hydration-target="…"`) and single-quoted JavaScript string literals (`'#{window_attr}'`, `window['#{window_attr}']`) in both `View` and `LinkBasedInjectionDetector`. A `"` or `'` in the name could break out and inject markup or script.

The gap analysis widened scope beyond the issue's original `view.rb`-only listing: the same pattern affected **all five strategies** in `link_based_injection_detector.rb`, plus window-name-interpolated JS line comments.

**Fix — two layers:**
- **Primary (parse time):** validate the `window` name against `/\A[a-zA-Z_][a-zA-Z0-9_]*\z/` in `RueDocument`; invalid names raise `RueDocument::ParseError`.
- **Defense in depth (render sites):** HTML-escape the name in attribute contexts (`ERB::Util.html_escape`) and JSON-encode it in `window[...]` script contexts (`JSONSerializer.dump_html_safe`), in both files. Previously window-name-interpolated JS comments are now static.

## L-1 — CSP nonce written to debug log

The raw per-response CSP nonce (a secret) was logged in **two** places — `CSP.generate_nonce` *and* `CSP#build_header` (the issue only noted the first). Both now log only `length` / `entropy_bits` / `nonce_used` metadata, never the value.

## Follow-on hardening (from Greptile review)

The same injection class for the other interpolated values in `link_based_injection_detector.rb` is now also fixed across all five strategies:
- **`endpoint_url` / `template_name`** — HTML-escaped in `href` / `data-lazy-src` attributes, JSON-encoded in `fetch(...)` / `import` / `loadData` / `loadPrefetched`.
- **`mount_selector`** (lazy) — JSON-encoded in `document.querySelector(...)` and the not-found `console.warn` message.

A single/double quote in any of these developer-controlled config values can no longer break out of its context.

## Tests
- New `spec/rhales/security/window_attribute_injection_spec.rb` (22 examples, written red-first): parse-time validation, view + detector render-site escaping for `window_attr`, config-value escaping (`endpoint_url`/`template_name`/`mount_selector`), and "nonce never logged".
- Tightened pre-existing assertions in `link_based_injection_detector_spec`, `hydration_strategies_integration_spec`, `enhanced_hydration_injector_spec`, and `logging_spec` that had encoded the **vulnerable** single-quoted output (including a "security test" that asserted a broken-out `window['userData; alert('XSS')']`).
- Full suite: **700 examples, 0 failures.** CHANGELOG updated.

## CI
Also pins `fallback_model: "claude-sonnet-4-6"` on `claude.yml` / `claude-code-review.yml` so the Claude Code Action stops 404-ing on its decommissioned default model (mirrors the `delano/otto` fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BdidgmV9X2ddi3yGw6f6hj