### PR TITLE
Prepare 0.7.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.1] - 2026-06-22
+
 ### Security
 - Validate the schema `window` attribute against a JavaScript identifier pattern
   (`/\A[a-zA-Z_][a-zA-Z0-9_]*\z/`) at parse time; invalid names raise

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    rhales (0.7.0)
+    rhales (0.7.1)
       json_schemer (~> 2)
       logger
       tilt (~> 2)

--- a/lib/rhales/version.rb
+++ b/lib/rhales/version.rb
@@ -5,6 +5,6 @@
 module Rhales
   # Version information for the RSFC gem
   unless defined?(Rhales::VERSION)
-    VERSION = '0.7.0'
+    VERSION = '0.7.1'
   end
 end


### PR DESCRIPTION
## Summary

Patch release **0.7.1** packaging the security fixes that have accumulated in the `[Unreleased]` changelog section since 0.7.0.

## Changes

- **`lib/rhales/version.rb`**: bump `Rhales::VERSION` `0.7.0` → `0.7.1`
- **`CHANGELOG.md`**: promote the `[Unreleased]` security entries into a dated `[0.7.1] - 2026-06-22` section
- **`Gemfile.lock`**: regenerated via `bundle install` (now pins `rhales (0.7.1)`)

## Included in this release (Security)

- Validate the schema `window` attribute against a JS identifier pattern at parse time; invalid names raise `RueDocument::ParseError` (#57)
- Escape the window name at every hydration render site (HTML attributes + `window[...]` JS contexts) in `View` and `LinkBasedInjectionDetector` (#57)
- Stop logging the raw CSP nonce value; `CSP.generate_nonce` / `CSP#build_header` now log only length/entropy/usage metadata (#57)
- Escape interpolated config values (`endpoint_url`, `template_name`, `mount_selector`) in `LinkBasedInjectionDetector` (#59 review)

## Verification

- `bundle install` ✅
- `bundle exec rspec spec/rhales/` → **700 examples, 0 failures** ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XhPnQk7azj3Sr6WAcaKJ8C)_