### PR TITLE
Harden template-name resolution and optimize mount-point detection (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lazy `mount_selector` (JSON-encoded in `document.querySelector(...)`), so a
   single/double quote in those config values can no longer break out of its
   context (#59 review).
+- Validate template names in `View#resolve_template_path` to prevent path
+  traversal. Names may still use forward slashes for subdirectories, but
+  parent-directory references (`..`), embedded null bytes, and absolute paths
+  are rejected with `View::TemplateNotFoundError`. This matters because
+  `HydrationEndpoint` is designed to be wired to an API route, so a
+  request-derived template name can no longer escape the configured template
+  directories to read arbitrary files (#22).
+
+### Performance
+- `MountPointDetector#detect` now scans the rendered HTML a single time using
+  one combined alternation pattern built from all selectors, instead of
+  re-scanning the whole document once per selector. Results are memoized per
+  detector instance keyed by `[template_html, selectors]`, and `View` reuses a
+  single detector, so repeated detection on identical HTML reuses the prior
+  result and its `SafeInjectionValidator` work. Selection semantics
+  (selector-priority tie-breaking, earliest safe position) are unchanged (#22).
 
 ## [0.7.0] - 2026-06-21
 

--- a/lib/rhales/core/view.rb
+++ b/lib/rhales/core/view.rb
@@ -229,6 +229,8 @@ module Rhales
 
     # Resolve template path
     def resolve_template_path(template_name)
+      validate_template_name!(template_name)
+
       # Check configured template paths first
       if config && config.template_paths && !config.template_paths.empty?
         config.template_paths.each do |path|
@@ -251,6 +253,28 @@ module Rhales
         File.join(config.template_paths.first, "#{template_name}.rue")
       else
         web_path
+      end
+    end
+
+    # Guard against path-traversal in template names.
+    #
+    # Template names may contain forward slashes to address subdirectories
+    # (e.g. "web/homepage"), but must not reference parent directories, embed
+    # null bytes, or be absolute paths. HydrationEndpoint exposes template
+    # names to API callers, so a name derived from request input must never be
+    # able to escape the configured template directories and read arbitrary
+    # files off disk.
+    def validate_template_name!(template_name)
+      unless template_name.is_a?(String) && !template_name.empty?
+        raise TemplateNotFoundError, "Invalid template name: #{template_name.inspect}"
+      end
+
+      absolute  = template_name.start_with?('/') || template_name.match?(/\A[a-zA-Z]:[\\\/]/)
+      null_byte = template_name.bytes.include?(0)
+      traversal = template_name.split(%r{[\\/]}).include?('..')
+
+      if absolute || null_byte || traversal
+        raise TemplateNotFoundError, "Unsafe template name: #{template_name.inspect}"
       end
     end
 
@@ -317,8 +341,14 @@ module Rhales
       return nil unless config&.hydration
 
       custom_selectors = config.hydration.mount_point_selectors || []
-      detector = MountPointDetector.new
-      detector.detect(template_html, custom_selectors)
+      mount_point_detector.detect(template_html, custom_selectors)
+    end
+
+    # Memoized mount point detector. Reusing one instance lets its per-instance
+    # result cache avoid rebuilding a SafeInjectionValidator and re-scanning
+    # identical rendered HTML across calls within this view's lifetime.
+    def mount_point_detector
+      @mount_point_detector ||= MountPointDetector.new
     end
 
     # Build view composition for the given template

--- a/lib/rhales/hydration/mount_point_detector.rb
+++ b/lib/rhales/hydration/mount_point_detector.rb
@@ -21,42 +21,78 @@ module Rhales
   #
   # Default selectors are checked: ['#app', '#root', '[data-rsfc-mount]', '[data-mount]']
   # Custom selectors can be added via configuration and are combined with defaults.
+  #
+  # ## Performance
+  #
+  # Detection scans the HTML a single time using one combined alternation
+  # pattern built from all selectors, rather than re-scanning the whole
+  # document once per selector. Results are memoized per instance keyed by
+  # [template_html, selectors], so repeated detection on the same rendered
+  # HTML (e.g. across renders that reuse the detector) reuses the prior result
+  # and its SafeInjectionValidator work instead of recomputing.
   class MountPointDetector
     DEFAULT_SELECTORS = ['#app', '#root', '[data-rsfc-mount]', '[data-mount]'].freeze
 
+    def initialize
+      @cache = {}
+    end
+
     def detect(template_html, custom_selectors = [])
       selectors = (DEFAULT_SELECTORS + Array(custom_selectors)).uniq
-      scanner = StringScanner.new(template_html)
-      validator = SafeInjectionValidator.new(template_html)
-      mount_points = []
+      cache_key = [template_html, selectors]
+      return @cache[cache_key] if @cache.key?(cache_key)
 
-      selectors.each do |selector|
-        scanner.pos = 0
-        pattern = build_pattern(selector)
-
-        while scanner.scan_until(pattern)
-          # Calculate position where the full tag starts
-          tag_start_pos = find_tag_start(scanner, template_html)
-
-          # Only include mount points that are safe for injection
-          safe_position = find_safe_injection_position(validator, tag_start_pos)
-
-          if safe_position
-            mount_points << {
-              selector: selector,
-              position: safe_position,
-              original_position: tag_start_pos,
-              matched: scanner.matched
-            }
-          end
-        end
-      end
-
-      # Return earliest mount point by position
-      mount_points.min_by { |mp| mp[:position] }
+      @cache[cache_key] = compute_detection(template_html, selectors)
     end
 
     private
+
+    def compute_detection(template_html, selectors)
+      validator = SafeInjectionValidator.new(template_html)
+      pattern   = combined_pattern(selectors)
+      scanner   = StringScanner.new(template_html)
+      matches   = []
+
+      # Single pass over the HTML: the combined alternation finds every
+      # selector occurrence in document order, and the matching capture-group
+      # index tells us which selector produced it.
+      while scanner.scan_until(pattern)
+        selector  = selectors[matched_group_index(scanner, selectors.length)]
+        tag_start = find_tag_start(scanner, template_html)
+
+        # Only include mount points that are safe for injection
+        safe_position = find_safe_injection_position(validator, tag_start)
+        next unless safe_position
+
+        matches << {
+          selector: selector,
+          position: safe_position,
+          original_position: tag_start,
+          matched: scanner.matched,
+        }
+      end
+
+      # Preserve the original selection semantics: matches are considered in
+      # selector-priority order (then document order within a selector), and
+      # the earliest injection position wins. Ordering the matches this way
+      # before min_by reproduces the previous per-selector tie-breaking.
+      ordered = selectors.flat_map { |selector| matches.select { |mp| mp[:selector] == selector } }
+      ordered.min_by { |mp| mp[:position] }
+    end
+
+    # Build one alternation pattern from all selectors. Each selector's
+    # sub-pattern is wrapped in a capture group so the matched group index
+    # identifies which selector matched. None of the sub-patterns introduce
+    # their own capture groups, so group N corresponds to selector N-1.
+    def combined_pattern(selectors)
+      union = selectors.map { |selector| "(#{build_pattern(selector).source})" }.join('|')
+      Regexp.new(union, Regexp::IGNORECASE)
+    end
+
+    def matched_group_index(scanner, count)
+      count.times { |index| return index if scanner[index + 1] }
+      0
+    end
 
     def build_pattern(selector)
       case selector

--- a/lib/rhales/hydration/mount_point_detector.rb
+++ b/lib/rhales/hydration/mount_point_detector.rb
@@ -91,9 +91,22 @@ module Rhales
 
     def matched_group_index(scanner, count)
       count.times { |index| return index if scanner[index + 1] }
-      0
+
+      # Unreachable in normal operation: after a successful scan_until against
+      # combined_pattern exactly one wrapped selector group has captured. If
+      # none has, a build_pattern sub-pattern introduced its own capturing
+      # group and shifted the numbering, so fail loudly rather than silently
+      # attributing the match to the first selector.
+      raise 'MountPointDetector: no selector capture group matched; ' \
+            'build_pattern sub-patterns must not contain capturing groups'
     end
 
+    # Build the regex fragment that matches a single selector.
+    #
+    # INVARIANT: sub-patterns must not contain capturing groups. combined_pattern
+    # wraps each fragment in exactly one capture group and maps that group's
+    # index back to a selector, so any stray `(...)` here would shift the
+    # numbering and misattribute matches. Use non-capturing groups `(?:...)`.
     def build_pattern(selector)
       case selector
       when /^#(.+)$/

--- a/spec/rhales/mount_point_detector_spec.rb
+++ b/spec/rhales/mount_point_detector_spec.rb
@@ -188,5 +188,45 @@ RSpec.describe Rhales::MountPointDetector do
         expect(result[:selector]).to eq('#app')
       end
     end
+
+    context 'caching and single-pass scanning' do
+      it 'memoizes the result and builds the validator only once per input' do
+        html = '<div id="app"></div>'
+        expect(Rhales::SafeInjectionValidator).to receive(:new).once.and_call_original
+
+        first  = detector.detect(html)
+        second = detector.detect(html)
+
+        expect(second).to eq(first)
+        expect(second[:selector]).to eq('#app')
+      end
+
+      it 'computes separately when selectors differ' do
+        html = '<div class="widget" id="app"></div>'
+        expect(Rhales::SafeInjectionValidator).to receive(:new).twice.and_call_original
+
+        detector.detect(html)
+        detector.detect(html, ['.widget'])
+      end
+
+      it 'finds the earliest mount point in one pass across many selectors' do
+        html = '<section data-mount></section><div id="app"></div>'
+        result = detector.detect(html, ['.foo', '[data-bar]'])
+
+        expect(result[:selector]).to eq('[data-mount]')
+        expect(result[:position]).to eq(0)
+      end
+
+      it 'breaks position ties by selector priority, not document order' do
+        # Both selectors match the same tag (same tag-start position); the
+        # higher-priority default (#app) must win even though its attribute
+        # appears after the lower-priority one in the tag text.
+        html = '<div data-mount id="app"></div>'
+        result = detector.detect(html)
+
+        expect(result[:position]).to eq(0)
+        expect(result[:selector]).to eq('#app')
+      end
+    end
   end
 end

--- a/spec/rhales/view_template_path_traversal_spec.rb
+++ b/spec/rhales/view_template_path_traversal_spec.rb
@@ -1,0 +1,72 @@
+# spec/rhales/view_template_path_traversal_spec.rb
+#
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+# Template names can reach Rhales::View from request-facing code (notably
+# HydrationEndpoint, which is designed to be wired to an API route). A name
+# derived from request input must never be able to escape the configured
+# template directories and read arbitrary files off disk.
+RSpec.describe 'Rhales::View template name path-traversal protection' do
+  let(:view) { Rhales::View.new(nil) }
+
+  def resolve(name)
+    view.send(:resolve_template_path, name)
+  end
+
+  describe 'rejecting unsafe template names' do
+    unsafe_names = [
+      '../secrets',
+      '../../etc/passwd',
+      'web/../../../etc/passwd',
+      'web/../../config/database',
+      '..\\..\\windows\\system32\\config',
+      '/etc/passwd',
+      'C:\\Windows\\System32',
+      '..',
+    ]
+
+    unsafe_names.each do |bad_name|
+      it "raises TemplateNotFoundError for #{bad_name.inspect}" do
+        expect { resolve(bad_name) }
+          .to raise_error(Rhales::View::TemplateNotFoundError, /Unsafe template name|Invalid template name/)
+      end
+    end
+
+    it 'rejects names containing an embedded null byte' do
+      expect { resolve("web/#{0.chr}passwd") }
+        .to raise_error(Rhales::View::TemplateNotFoundError, /Unsafe template name/)
+    end
+
+    it 'rejects before any filesystem lookup occurs' do
+      # The validation guard raises with the "Unsafe" message; the not-found
+      # path (which only fires after File.exist? checks) uses a different one.
+      expect { resolve('../../etc/passwd') }
+        .to raise_error(Rhales::View::TemplateNotFoundError, /Unsafe template name/)
+    end
+
+    it 'rejects nil and empty names' do
+      expect { resolve(nil) }.to raise_error(Rhales::View::TemplateNotFoundError, /Invalid template name/)
+      expect { resolve('') }.to raise_error(Rhales::View::TemplateNotFoundError, /Invalid template name/)
+    end
+  end
+
+  describe 'accepting legitimate template names' do
+    safe_names = %w[
+      homepage
+      web/homepage
+      layouts/main
+      partials/header
+      a_b-c/d.e
+      deeply/nested/path/template
+    ]
+
+    safe_names.each do |good_name|
+      it "resolves #{good_name.inspect} to a .rue path" do
+        expect { resolve(good_name) }.not_to raise_error
+        expect(resolve(good_name)).to end_with("#{good_name}.rue")
+      end
+    end
+  end
+end


### PR DESCRIPTION
Addresses two still-relevant follow-ups from the PR #21 review tracked in #22. A full status review of every item in that issue was [posted as a comment](https://github.com/onetimesecret/rhales/issues/22#issuecomment-4765655598).

## Security — template-name path-traversal guard

`View#resolve_template_path` previously did `File.join(path, "#{template_name}.rue")` with no sanitization. Because `HydrationEndpoint` is designed to be wired to an API route, a request-derived template name could escape the configured template directories and read arbitrary files.

`validate_template_name!` now runs before any filesystem lookup and rejects:
- parent-directory references (`..` in any `/` or `\` segment)
- embedded null bytes
- absolute paths (POSIX `/...` and Windows `C:\...`)

Subdirectory names (`web/homepage`, `layouts/main`) are still allowed. Invalid/unsafe names raise `View::TemplateNotFoundError`.

## Performance — single-pass + cached mount-point detection

`MountPointDetector#detect` previously reset the scanner and re-scanned the whole document once per selector, and allocated a fresh `SafeInjectionValidator` on every call.

It now:
- scans the HTML a single time using one combined alternation pattern built from all selectors (the matching capture-group index identifies which selector matched)
- memoizes results per detector instance keyed by `[template_html, selectors]`, and `View` reuses one detector so repeated detection on identical HTML skips rebuilding the validator

Selection semantics are unchanged: matches are still ordered by selector priority (then document order) before picking the earliest safe position, so tie-breaking is byte-identical to the previous behavior. A regression test covers the tie-break case (`<div data-mount id="app">` still resolves to `#app`).

## Tests

- New `spec/rhales/view_template_path_traversal_spec.rb` (17 examples) covering unsafe/safe names, null bytes, and nil/empty input.
- Extended `spec/rhales/mount_point_detector_spec.rb` with caching (validator built once per input), per-selector cache separation, single-pass multi-selector detection, and priority tie-breaking.
- Full suite: **721 examples, 0 failures**.

CHANGELOG updated under `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRkj1DGEsE4Vgi1H7XdDQx

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRkj1DGEsE4Vgi1H7XdDQx)_