### PR TITLE
Refactor agent guidance and update documentation references

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -64,7 +64,7 @@ jobs:
             - Security concerns
             - Test coverage
 
-            Use the repository's CLAUDE.md or AGENTS.md for guidance on style and conventions. Be constructive and helpful in your feedback.
+            Use the repository's AGENTS.md for guidance on style and conventions. Be constructive and helpful in your feedback.
 
           # Use sticky comments to reuse the same comment on subsequent pushes to the same PR
           use_sticky_comment: true

--- a/.gitignore
+++ b/.gitignore
@@ -48,7 +48,7 @@ bin/rspec
 [A-Z]*.ts
 [A-Z]*.md
 
-!CLAUDE.md
+!AGENTS.md
 
 # Environment files
 .env*

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,8 +90,7 @@ For complex features requiring parallel work:
 
 ## Resuming work
 
-Returning after a break? Re-orient with **Map → Mail → Mess**, then act on the
-first hit:
+Returning after a break? Re-orient with **Map → Mail → Mess**:
 
 1. **Map — what's planned.** Read the first `todo` in the active RFD
    (`docs/rfd/`), the `Status:` of any `docs/adr/`, and `CHANGELOG.md`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,21 +90,17 @@ For complex features requiring parallel work:
 
 ## Resuming work
 
-Returning after a break? Re-orient with **Map → Mail → Mess**:
+Re-orient with **Map → Mail → Mess**:
 
-1. **Map — what's planned.** Read the first `todo` in the active RFD
-   (`docs/rfd/`), the `Status:` of any `docs/adr/`, and `CHANGELOG.md`
-   `[Unreleased]`.
-2. **Mail — what's waiting on me.** Open PRs: red CI, unresolved review threads,
-   and each PR description's `## Next` section. Note what merged while you were
-   away.
-3. **Mess — what's half-done locally.** `git fetch`, then
-   `git branch --show-current`, `git status`, `git stash list`, and
-   `git log --oneline -10`.
+1. **Map — the plan.** First `todo` in the active RFD (`docs/rfd/`), any
+   `docs/adr/` `Status:`, and `CHANGELOG.md` `[Unreleased]`.
+2. **Mail — what's waiting.** Open PRs: red CI, unresolved review threads, each
+   PR's `## Next`. Note what merged or closed since.
+3. **Mess — local state.** `git fetch`, then `git branch --show-current`,
+   `git status`, `git stash list`, `git log --oneline -10`.
 
-Pick the next step as the first that fires: a PR waiting on you → a roadmap
-`todo` → reconciling local half-finished work.
+Next step is the first that fires: a PR waiting on you → a roadmap `todo` →
+local half-finished work.
 
-**Before you stop**, leave a breadcrumb so the next session is reading, not
-reconstructing: flip a step's status in the RFD, update the PR's `## Next`
-section, or add a `TODO(next):` note in the final commit.
+Before stopping, leave a breadcrumb: flip a step's `Status:` in the RFD, update
+the PR's `## Next`, or add a `TODO(next):` to the final commit.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@
 ## Workflow: Feature Implementation
 
 ### 1. Research & Planning Phase
-IMPORTANT: Always research and plan before coding. Use "think" or "think hard" for complex features.
+IMPORTANT: Always research and plan before coding. Spend extra planning effort on complex or security-sensitive features.
 
 - Read relevant files and documentation WITHOUT writing code yet
 - Understand the two-layer data system (app, props)
@@ -53,7 +53,7 @@ Follow test-driven development when possible:
 For complex features requiring parallel work:
 - Use git worktrees for independent components
 - Keep adapter changes separate from core changes
-- Use /clear between unrelated tasks to optimize context
+- Start a fresh session/context between unrelated tasks to keep context focused
 - Document progress in CHANGELOG.md
 
 ## Project-Specific Notes
@@ -87,3 +87,25 @@ For complex features requiring parallel work:
 - Test all three context layers independently
 - Verify template caching behavior
 - Check false/nil handling explicitly
+
+## Resuming work
+
+Returning after a break? Re-orient with **Map → Mail → Mess**, then act on the
+first hit:
+
+1. **Map — what's planned.** Read the first `todo` in the active RFD
+   (`docs/rfd/`), the `Status:` of any `docs/adr/`, and `CHANGELOG.md`
+   `[Unreleased]`.
+2. **Mail — what's waiting on me.** Open PRs: red CI, unresolved review threads,
+   and each PR description's `## Next` section. Note what merged while you were
+   away.
+3. **Mess — what's half-done locally.** `git fetch`, then
+   `git branch --show-current`, `git status`, `git stash list`, and
+   `git log --oneline -10`.
+
+Pick the next step as the first that fires: a PR waiting on you → a roadmap
+`todo` → reconciling local half-finished work.
+
+**Before you stop**, leave a breadcrumb so the next session is reading, not
+reconstructing: flip a step's status in the RFD, update the PR's `## Next`
+section, or add a `TODO(next):` note in the final commit.


### PR DESCRIPTION
## Summary
This PR updates project documentation to clarify agent workflows and consolidates guidance references. The changes improve clarity around planning effort for complex features, context management between tasks, and provide a structured approach for resuming work after breaks.

## Key Changes
- **AGENTS.md**: Updated planning guidance to emphasize "extra planning effort" for complex/security-sensitive features instead of referencing specific prompt commands
- **AGENTS.md**: Replaced `/clear` command reference with "start a fresh session/context" for better clarity on context management between unrelated tasks
- **AGENTS.md**: Added new "Resuming work" section with a structured **Map → Mail → Mess** framework for re-orienting after breaks, including:
  - Map: Review planned work (RFDs, ADRs, CHANGELOG)
  - Mail: Check waiting PRs and review threads
  - Mess: Assess local work state (git status, stashes, recent commits)
  - Guidance on leaving breadcrumbs for the next session
- **claude-code-review.yml**: Updated workflow to reference `AGENTS.md` instead of `CLAUDE.md` for code review guidance
- **.gitignore**: Updated exception from `!CLAUDE.md` to `!AGENTS.md` to reflect the primary guidance document

## Implementation Details
These changes consolidate project guidance into a single authoritative document (AGENTS.md) and provide more actionable, context-aware workflows for both initial feature implementation and resuming interrupted work. The new "Resuming work" section addresses a common pain point by providing a systematic approach to re-orient without reconstructing context.

https://claude.ai/code/session_01LRkj1DGEsE4Vgi1H7XdDQx