### PR TITLE
ci: workflow standardization (YARD, code-smells checkout, release Ruby, fork/bot guard)

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -25,10 +25,21 @@ jobs:
     #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
 
     runs-on: ubuntu-latest
-    if: |
-      (github.event.action == 'opened') ||
-      (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
-      (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'claude-review'))
+    # Run only when ALL of the following hold:
+    #   1. Author is not a bot (renovate, dependabot, etc. surface as 'name[bot]').
+    #   2. PR head is not from a fork. Fork PRs run without repository secrets, so
+    #      CLAUDE_CODE_OAUTH_TOKEN is empty and the action would fail.
+    #   3. The event is a freshly opened PR, a 'claude-review' label add, or a push
+    #      to a PR that already carries the 'claude-review' label.
+    if: ${{
+      !endsWith(github.actor, '[bot]') &&
+      !github.event.pull_request.head.repo.fork &&
+      (
+        (github.event.action == 'opened') ||
+        (github.event.action == 'labeled' && github.event.label.name == 'claude-review') ||
+        (github.event.action == 'synchronize' && contains(github.event.pull_request.labels.*.name, 'claude-review'))
+      )
+      }}
 
     permissions:
       contents: read

--- a/.github/workflows/code-smells.yml
+++ b/.github/workflows/code-smells.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -91,7 +91,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1

--- a/.github/workflows/release-gem.yml
+++ b/.github/workflows/release-gem.yml
@@ -132,7 +132,7 @@ jobs:
         uses: ruby/setup-ruby@afeafc3d1ab54a631816aba4c914a0081c12ff2f # v1.310.0
         with:
           bundler-cache: true
-          ruby-version: ruby   # latest stable Ruby installed by setup-ruby
+          ruby-version: "3.3"   # pinned to match the otto/familia release builds
 
       - name: Verify release tag matches Rhales::VERSION
         env:

--- a/.github/workflows/yardoc.yml
+++ b/.github/workflows/yardoc.yml
@@ -6,8 +6,11 @@ on:
       - main
     paths:
       - 'lib/**/*'
+      - 'docs/**/*'
       - 'README.md'
       - 'CHANGELOG.md'
+      - 'CHANGELOG.rst'
+      - 'LICENSE.txt'
       - '.yardopts'
       - '.github/workflows/yardoc.yml'
   workflow_dispatch:
@@ -17,8 +20,9 @@ permissions:
   pages: write
   id-token: write
 
-# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
-# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+# Allow only one concurrent deployment, skipping runs queued between the run
+# in-progress and latest queued. Do NOT cancel in-progress runs so production
+# deployments can complete.
 concurrency:
   group: "pages"
   cancel-in-progress: false
@@ -31,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6.0.3
         with:
           fetch-depth: 0
 
@@ -41,55 +45,33 @@ jobs:
           ruby-version: '3.4'
           bundler-cache: true
 
-      - name: Configure YARD documentation parameters
-        run: |
-          # Create comprehensive .yardopts configuration
-          cat > .yardopts << 'EOF'
-          --protected
-          --private
-          --markup markdown
-          --markup-provider kramdown
-          --output-dir doc
-          --readme README.md
-          --files CHANGELOG.md,LICENSE.txt
-          --exclude spec/**/*
-          --exclude demo/**/*
-          --exclude examples/**/*
-          --exclude apps/**/*
-          lib/**/*.rb
-          -
-          README.md
-          CHANGELOG.md
-          EOF
-
-      - name: Generate comprehensive documentation
+      - name: Generate documentation
+        # Uses the repository's committed .yardopts as the single source of
+        # truth for the output dir, includes/excludes, markup, and tags.
         run: |
           echo "::group::YARD Documentation Generation"
-          bundle exec yard stats --list-undoc
+          bundle exec yard stats --list-undoc || true
           bundle exec yard doc
           echo "::endgroup::"
 
-      - name: Validate documentation completeness
+      - name: Disable Jekyll processing
+        # YARD emits files and directories that begin with underscores; the
+        # .nojekyll marker stops GitHub Pages from stripping them.
+        run: touch doc/.nojekyll
+
+      - name: Validate documentation output
         run: |
           echo "::group::Documentation Validation"
           if [ ! -d "doc" ]; then
-            echo "Error: Documentation directory not generated"
+            echo "Error: documentation directory 'doc' was not generated." >&2
+            echo "Ensure .yardopts sets '--output-dir doc'." >&2
             exit 1
           fi
-
-          # Check for essential files
-          required_files=("index.html" "file.README.html" "file.CHANGELOG.html")
-          for file in "${required_files[@]}"; do
-            if [ ! -f "doc/$file" ]; then
-              echo "Warning: Expected file doc/$file not found"
-            fi
-          done
-
-          # Display documentation statistics
-          echo "Generated documentation files:"
-          find doc -name "*.html" | wc -l
-          echo "Total documentation size:"
-          du -sh doc/
+          if [ ! -f "doc/index.html" ]; then
+            echo "Warning: doc/index.html not found"
+          fi
+          echo "Generated HTML files: $(find doc -name '*.html' | wc -l)"
+          echo "Total documentation size: $(du -sh doc/ | cut -f1)"
           echo "::endgroup::"
 
       - name: Setup GitHub Pages configuration
@@ -107,6 +89,8 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build-docs
+    outputs:
+      page_url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary

Follow-up to #65 (merged). That PR landed the Ruby 4.0 matrix; this one carries the **workflow standardization** that was discussed but hadn't been split into its own PR yet.

## Changes
- **`yardoc.yml`** — build from the **committed `.yardopts`** (single source of truth) instead of generating one inline; `actions/checkout` → `v6.0.3`; expose `page_url` as a `deploy-pages` job output so the completion notice links correctly.
- **`code-smells.yml`** — `actions/checkout` v4 → v6.0.3.
- **`release-gem.yml`** — pin the gem build to Ruby **3.3** (was `ruby`/latest) to match otto/familia.
- **`claude-code-review.yml`** — port onetimesecret's **fork/bot guard** (skip `*[bot]` actors and fork PRs, which run without secrets so the action would fail). Cherry-picked cleanly on top of main's current review workflow.

Part of a 3-repo set (familia/otto/rhales). Squash-merge recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01P9DBMriY9snxDUEAG7EJE4

---
_Generated by [Claude Code](https://claude.ai/code/session_01P9DBMriY9snxDUEAG7EJE4)_