### PR TITLE
Add code coverage reporting to GitHub Code Quality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,8 @@ on:
 
 permissions:
   contents: read
+  # Required to upload coverage data to GitHub Code Quality.
+  code-quality: write
 
 jobs:
   test:
@@ -30,6 +32,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Check out the PR head commit (not the merge commit) so coverage
+          # line numbers map correctly to the diff for GitHub Code Quality.
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
@@ -38,10 +44,23 @@ jobs:
           bundler-cache: true
 
       - name: Run RSpec tests
+        # Generate a Cobertura coverage report on a single Ruby version only.
+        env:
+          COVERAGE: ${{ matrix.ruby == '3.4' && 'true' || '' }}
         run: bundle exec rspec
 
       - name: Run Rhales-specific tests
         run: bundle exec rake rhales:test
+
+      - name: Upload coverage report
+        # Only the coverage-generating version uploads; skip forked PRs, which
+        # cannot write Code Quality data.
+        if: matrix.ruby == '3.4' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: actions/upload-code-coverage@v1
+        with:
+          file: coverage/coverage.xml
+          language: Ruby
+          label: code-coverage/rspec
 
   gem-build:
     timeout-minutes: 10

--- a/Gemfile
+++ b/Gemfile
@@ -9,6 +9,7 @@ group :development, :test do
   gem 'reek', '~> 6.5'
   gem 'rspec', '~> 3.12'
   gem 'simplecov', '~> 0.22'
+  gem 'simplecov-cobertura', '~> 3.2' # Cobertura XML output for GitHub Code Quality
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,9 @@ GEM
       docile (~> 1.1)
       simplecov-html (~> 0.11)
       simplecov_json_formatter (~> 0.1)
+    simplecov-cobertura (3.2.0)
+      rexml
+      simplecov (~> 0.19)
     simplecov-html (0.13.1)
     simplecov_json_formatter (0.1.4)
     simpleidn (0.2.3)
@@ -181,6 +184,7 @@ DEPENDENCIES
   rubocop-rspec
   rubocop-thread_safety
   simplecov (~> 0.22)
+  simplecov-cobertura (~> 3.2)
   stackprof
   syntax_tree
   yard (~> 0.9)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -3,6 +3,21 @@
 # frozen_string_literal: true
 
 require 'bundler/setup'
+
+# Generate a code coverage report when COVERAGE is set. CI sets this on a
+# single Ruby version and uploads the resulting Cobertura XML to GitHub Code
+# Quality. SimpleCov must start before 'rhales' is required so every file in
+# lib/ is tracked.
+if ENV['COVERAGE'] == 'true'
+  require 'simplecov'
+  require 'simplecov-cobertura'
+
+  SimpleCov.start do
+    add_filter '/spec/'
+    formatter SimpleCov::Formatter::CoberturaFormatter
+  end
+end
+
 require 'rhales'
 
 # Configure Rhales for testing


### PR DESCRIPTION
## Summary
This PR adds automated code coverage reporting to GitHub Code Quality by integrating SimpleCov with Cobertura XML output format and configuring the CI workflow to upload coverage reports.

## Key Changes
- **CI Workflow Updates** (`ci.yml`):
  - Added `code-quality: write` permission to enable uploading coverage data to GitHub Code Quality
  - Modified checkout step to use PR head commit SHA instead of merge commit for accurate diff line mapping
  - Added conditional `COVERAGE` environment variable that enables coverage generation only on Ruby 3.4
  - Added new "Upload coverage report" step that uploads Cobertura XML to GitHub Code Quality, with safeguards to skip forked PRs

- **Coverage Configuration** (`spec/spec_helper.rb`):
  - Added conditional SimpleCov initialization when `COVERAGE=true` environment variable is set
  - Configured SimpleCov to use Cobertura XML formatter for GitHub Code Quality compatibility
  - Ensured SimpleCov starts before requiring 'rhales' to track all files in lib/
  - Excluded spec/ directory from coverage metrics

- **Dependencies** (`Gemfile`):
  - Added `simplecov-cobertura` gem (~> 3.2) to generate Cobertura XML output format

## Implementation Details
- Coverage generation is limited to a single Ruby version (3.4) to avoid redundant processing
- The workflow skips coverage uploads for forked PRs, which lack write permissions to Code Quality
- The checkout step uses the PR head commit to ensure coverage line numbers align correctly with the GitHub diff view

https://claude.ai/code/session_01TfZU5oEacUhSTheXyh5wEe